### PR TITLE
v1.4

### DIFF
--- a/GenericSynthesisPatcher/Helpers/Action/BasicGetterSetterAction.cs
+++ b/GenericSynthesisPatcher/Helpers/Action/BasicGetterSetterAction.cs
@@ -1,0 +1,106 @@
+using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace GenericSynthesisPatcher.Helpers.Action
+{
+    public abstract class BasicGetterSetterAction<TGetter, TSetter> : IRecordAction
+    {
+        private const int ClassLogCode = 0x1B;
+
+        protected BasicGetterSetterAction ()
+        {
+        }
+
+        public virtual bool CanFill () => true;
+
+        public virtual bool CanForward () => true;
+
+        public virtual bool CanForwardSelfOnly () => false;
+
+        public virtual bool CanMatch () => false;
+
+        public virtual bool CanMerge () => false;
+
+        public virtual int Fill (ProcessingKeys proKeys)
+        {
+            if (!Mod.TryGetProperty<TGetter>(proKeys.Record, proKeys.Property.PropertyName, out var curValue)
+             || !proKeys.TryGetFillValueAs(out TSetter? newValue))
+                return -1;
+
+            return Fill(proKeys, curValue, newValue);
+        }
+
+        public virtual int Forward (ProcessingKeys proKeys, IModContext<ISkyrimMod, ISkyrimModGetter, IMajorRecord, IMajorRecordGetter> forwardContext)
+                    => (Mod.TryGetProperty<TGetter>(proKeys.Record, proKeys.Property.PropertyName, out var curValue)
+                     && Mod.TryGetProperty<TGetter>(forwardContext.Record, proKeys.Property.PropertyName, out var newValue)) ?
+                        Fill(proKeys, curValue, newValue)
+                        : -1;
+
+        public virtual int ForwardSelfOnly (ProcessingKeys proKeys, IModContext<ISkyrimMod, ISkyrimModGetter, IMajorRecord, IMajorRecordGetter> forwardContext) => throw new NotImplementedException();
+
+        public virtual bool MatchesOrigin (ProcessingKeys proKeys)
+        {
+            var origin = proKeys.GetOriginRecord();
+            return origin != null
+                        && Mod.TryGetProperty<TGetter>(proKeys.Context.Record, proKeys.Property.PropertyName, out var curValue)
+                        && Mod.TryGetProperty<TGetter>(origin, proKeys.Property.PropertyName, out var originValue)
+                        && Equals(curValue, originValue);
+        }
+
+        public virtual bool MatchesRule (ProcessingKeys proKeys) => throw new NotImplementedException();
+
+        public virtual int Merge (ProcessingKeys proKeys) => throw new NotImplementedException();
+
+        /// <summary>
+        /// Compare values of getter and setter.
+        /// </summary>
+        /// <param name="lhs">Getter</param>
+        /// <param name="rhs">Setter</param>
+        /// <returns>True if values both match</returns>
+        protected abstract bool CompareValues (TGetter? lhs, TSetter? rhs);
+
+        /// <summary>
+        /// Update value on record if new and current values don't match.
+        /// </summary>
+        /// <param name="proKeys"></param>
+        /// <param name="curValue">Current value in property</param>
+        /// <param name="newValue">Value to set if different to current</param>
+        /// <returns>
+        ///     -1 if failed to get patch record
+        ///     0 if both values matched already
+        ///     1 if updated
+        /// </returns>
+        protected virtual int Fill (ProcessingKeys proKeys, TGetter? curValue, TSetter? newValue)
+        {
+            if (CompareValues(curValue, newValue))
+                return 0;
+
+            if (!Mod.TrySetProperty(proKeys.GetPatchRecord(), proKeys.Property.PropertyName, newValue))
+                return -1;
+
+            Global.DebugLogger?.Log(ClassLogCode, "Changed.", propertyName: proKeys.Property.PropertyName);
+            return 1;
+        }
+
+        /// <summary>
+        /// Update value on record if new and current values don't match.
+        /// </summary>
+        /// <param name="proKeys"></param>
+        /// <param name="curValue">Current value in property</param>
+        /// <param name="newValue">Value to set if different to current</param>
+        /// <returns>
+        ///     -1 if failed to get patch record
+        ///     0 if both values matched already
+        ///     1 if updated
+        /// </returns>
+        protected virtual int Fill (ProcessingKeys proKeys, TGetter? curValue, TGetter? newValue) => Fill(proKeys, curValue, GetSetter(newValue));
+
+        /// <summary>
+        /// Gets setter type from values in getter type
+        /// </summary>
+        /// <param name="getter">Getter of values to convert to setter</param>
+        /// <returns>TSetter object with values from getter</returns>
+        protected abstract TSetter? GetSetter (TGetter? getter);
+    }
+}

--- a/GenericSynthesisPatcher/Helpers/Action/FormLinkAction.cs
+++ b/GenericSynthesisPatcher/Helpers/Action/FormLinkAction.cs
@@ -134,8 +134,13 @@ namespace GenericSynthesisPatcher.Helpers.Action
                 return 0;
             }
 
-            if (!Mod.TrySetProperty(proKeys.GetPatchRecord(), proKeys.Property.PropertyName, newValue))
+            if (!Mod.TryGetPropertyForEditing<IFormLink<TMajor>>(proKeys.GetPatchRecord(), proKeys.Property.PropertyName, out var formLink))
                 return -1;
+
+            if (newValue == null || newValue.IsNull)
+                formLink.SetToNull();
+            else
+                formLink.SetTo(newValue.FormKey);
 
             Global.DebugLogger?.Log(ClassLogCode, "Updated.", propertyName: proKeys.Property.PropertyName);
             return 1;

--- a/GenericSynthesisPatcher/Helpers/Action/FormLinksAction.cs
+++ b/GenericSynthesisPatcher/Helpers/Action/FormLinksAction.cs
@@ -242,7 +242,7 @@ namespace GenericSynthesisPatcher.Helpers.Action
             }
 
             var add = newList.WhereNotIn(curList);
-            var del = curList.WhereNotIn(newList);
+            var del = curList.WhereNotIn(newList).ToList();
 
             if (!add.Any() && !del.Any())
                 return 0;

--- a/GenericSynthesisPatcher/Helpers/Action/FormLinksWithDataAction.cs
+++ b/GenericSynthesisPatcher/Helpers/Action/FormLinksWithDataAction.cs
@@ -328,7 +328,7 @@ namespace GenericSynthesisPatcher.Helpers.Action
             }
 
             var add = newList.WhereNotIn(curList);
-            var del = curList.WhereNotIn(newList);
+            var del = curList.WhereNotIn(newList).ToList();
 
             if (!add.Any() && !del.Any())
                 return 0;

--- a/GenericSynthesisPatcher/Helpers/Action/MemorySliceByteAction.cs
+++ b/GenericSynthesisPatcher/Helpers/Action/MemorySliceByteAction.cs
@@ -1,0 +1,13 @@
+using Noggog;
+
+namespace GenericSynthesisPatcher.Helpers.Action
+{
+    public class MemorySliceByteAction : BasicGetterSetterAction<ReadOnlyMemorySlice<byte>, MemorySlice<byte>>
+    {
+        public static readonly MemorySliceByteAction Instance = new();
+
+        protected override bool CompareValues (ReadOnlyMemorySlice<byte> lhs, MemorySlice<byte> rhs) => lhs.SequenceEqual(rhs);
+
+        protected override MemorySlice<byte> GetSetter (ReadOnlyMemorySlice<byte> getter) => new MemorySlice<byte>([.. getter]);
+    }
+}

--- a/GenericSynthesisPatcher/Helpers/Action/ObjectBoundsAction.cs
+++ b/GenericSynthesisPatcher/Helpers/Action/ObjectBoundsAction.cs
@@ -1,0 +1,34 @@
+using Mutagen.Bethesda.Skyrim;
+
+namespace GenericSynthesisPatcher.Helpers.Action
+{
+    public class ObjectBoundsAction : BasicGetterSetterAction<IObjectBoundsGetter, ObjectBounds>
+    {
+        public static readonly ObjectBoundsAction Instance = new();
+
+        protected override bool CompareValues (IObjectBoundsGetter? lhs, ObjectBounds? rhs)
+        {
+            if (lhs == null && rhs == null)
+                return true;
+
+            if (lhs == null || rhs == null)
+                return false;
+
+            return
+                lhs.First.Equals(rhs.First) &&
+                lhs.Second.Equals(rhs.Second);
+        }
+
+        protected override ObjectBounds? GetSetter (IObjectBoundsGetter? getter)
+        {
+            if (getter == null)
+                return null;
+
+            return new ObjectBounds
+            {
+                First = getter.First,
+                Second = getter.Second
+            };
+        }
+    }
+}

--- a/GenericSynthesisPatcher/Helpers/RecordPropertyMappings.cs
+++ b/GenericSynthesisPatcher/Helpers/RecordPropertyMappings.cs
@@ -15,14 +15,14 @@ namespace GenericSynthesisPatcher.Helpers
         private static readonly HashSet<IRecordProperty> propertyAliases = new(comparer: new RecordPropertyComparer());
         private static readonly HashSet<IRecordProperty> propertyMappings = new(comparer: new RecordPropertyComparer());
 
-        public static IReadOnlyList<PropertyAliasMapping> AllAliases => propertyAliases.Select(a => (PropertyAliasMapping)a).ToList().AsReadOnly();
-        public static IReadOnlyList<RecordPropertyMapping> AllRPMs => propertyMappings.Select(a => (RecordPropertyMapping)a).ToList().AsReadOnly();
-
         static RecordPropertyMappings ()
         {
             PopulateMappings();
             PopulateAliases();
         }
+
+        public static IReadOnlyList<PropertyAliasMapping> AllAliases => propertyAliases.Select(a => (PropertyAliasMapping)a).ToList().AsReadOnly();
+        public static IReadOnlyList<RecordPropertyMapping> AllRPMs => propertyMappings.Select(a => (RecordPropertyMapping)a).ToList().AsReadOnly();
 
         public static IReadOnlyList<string> GetAllAliases (Type type, string propertyName)
         {
@@ -73,12 +73,15 @@ namespace GenericSynthesisPatcher.Helpers
             Add(null                                 , "DataFlags"  , nameof(IAmmunitionGetter.Flags));
             Add(null                                 , "DESC"       , nameof(IAmmunitionGetter.Description));
             Add(null                                 , "EAMT"       , nameof(IArmorGetter.EnchantmentAmount));
+            Add(null                                 , "EDID"       , nameof(IArmorGetter.EditorID));
             Add(null                                 , "EITM"       , nameof(IArmorGetter.ObjectEffect));
             Add(null                                 , "ETYP"       , nameof(IWeaponGetter.EquipmentType));
             Add(null                                 , "FNAM"       , nameof(IAmmunitionGetter.Flags));
             Add(null                                 , "FULL"       , nameof(INamedGetter.Name));
             Add(null                                 , "Item"       , nameof(IContainerGetter.Items));
             Add(null                                 , "KWDA"       , nameof(IKeywordedGetter.Keywords));
+            Add(null                                 , "LVLD"       , nameof(ILeveledItemGetter.ChanceNone));
+            Add(null                                 , "LVLG"       , nameof(ILeveledItemGetter.Global));
             Add(null                                 , "OBND"       , nameof(IArmorGetter.ObjectBounds));
             Add(null                                 , "ONAM"       , nameof(INpcGetter.ShortName));
             Add(null                                 , "RecordFlags", nameof(IAmmunitionGetter.MajorFlags));
@@ -118,6 +121,8 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IBookGetter)                  , "CNAM"       , nameof(IBookGetter.Description));
             Add(typeof(IBookGetter)                  , "DESC"       , nameof(IBookGetter.BookText));
             Add(typeof(IBookGetter)                  , "INAM"       , nameof(IBookGetter.InventoryArt));
+            Add(typeof(ICameraPathGetter)            , "ANAM"       , nameof(ICameraPathGetter.RelatedPaths));
+            Add(typeof(ICameraPathGetter)            , "SNAM"       , nameof(ICameraPathGetter.Shots));
             Add(typeof(ICameraShotGetter)            , "MNAM"       , nameof(ICameraShotGetter.ImageSpaceModifier));
             Add(typeof(ICellGetter)                  , "LTMP"       , nameof(ICellGetter.LightingTemplate));
             Add(typeof(ICellGetter)                  , "TVDT"       , nameof(ICellGetter.OcclusionData));
@@ -128,8 +133,10 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(ICellGetter)                  , "XCLW"       , nameof(ICellGetter.WaterHeight));
             Add(typeof(ICellGetter)                  , "XCLX"       , nameof(ICellGetter.Grid));
             Add(typeof(ICellGetter)                  , "XCMO"       , nameof(ICellGetter.Music));
+            Add(typeof(ICellGetter)                  , "XRNK"       , nameof(ICellGetter.FactionRank));
             Add(typeof(ICellGetter)                  , "XILL"       , nameof(ICellGetter.LockList));
             Add(typeof(ICellGetter)                  , "XNAM"       , nameof(ICellGetter.WaterNoiseTexture));
+            Add(typeof(ICellGetter)                  , "XOWN"       , nameof(ICellGetter.Owner));
             Add(typeof(ICellGetter)                  , "XWEM"       , nameof(ICellGetter.WaterEnvironmentMap));
             Add(typeof(IClimateGetter)               , "FNAM"       , nameof(IClimateGetter.SunTexture));
             Add(typeof(IClimateGetter)               , "GNAM"       , nameof(IClimateGetter.SunGlareTexture));
@@ -138,6 +145,7 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(ICollisionLayerGetter)        , "FNAM"       , nameof(ICollisionLayerGetter.DebugColor));
             Add(typeof(ICollisionLayerGetter)        , "GNAM"       , nameof(ICollisionLayerGetter.Flags));
             Add(typeof(ICollisionLayerGetter)        , "MNAM"       , nameof(ICollisionLayerGetter.Name));
+            Add(typeof(IColorRecordGetter)           , "CNAM"       , nameof(IColorRecordGetter.Color));
             Add(typeof(IColorRecordGetter)           , "FNAM"       , nameof(IColorRecordGetter.Playable));
             Add(typeof(ICombatStyleGetter)           , "CSLR"       , nameof(ICombatStyleGetter.LongRangeStrafeMult));
             Add(typeof(IConstructibleObjectGetter)   , "BNAM"       , nameof(IConstructibleObjectGetter.WorkbenchKeyword));
@@ -189,17 +197,58 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IFurnitureGetter)             , "XMRK"       , nameof(IFurnitureGetter.ModelFilename));
             Add(typeof(IHazardGetter)                , "MNAM"       , nameof(IHazardGetter.ImageSpaceModifier));
             Add(typeof(IHeadPartGetter)              , "CNAM"       , nameof(IHeadPartGetter.Color));
+            Add(typeof(IHeadPartGetter)              , "HNAM"       , nameof(IHeadPartGetter.ExtraParts));
             Add(typeof(IHeadPartGetter)              , "PNAM"       , nameof(IHeadPartGetter.Type));
             Add(typeof(IHeadPartGetter)              , "Race"       , nameof(IHeadPartGetter.ValidRaces));
             Add(typeof(IHeadPartGetter)              , "Races"      , nameof(IHeadPartGetter.ValidRaces));
             Add(typeof(IHeadPartGetter)              , "RNAM"       , nameof(IHeadPartGetter.ValidRaces));
             Add(typeof(IHeadPartGetter)              , "TNAM"       , nameof(IHeadPartGetter.TextureSet));
+            Add(typeof(IIdleAnimationGetter)         , "ANAM"       , nameof(IIdleAnimationGetter.RelatedIdles));
             Add(typeof(IIdleAnimationGetter)         , "DNAM"       , nameof(IIdleAnimationGetter.Filename));
             Add(typeof(IIdleAnimationGetter)         , "ENAM"       , nameof(IIdleAnimationGetter.AnimationEvent));
             Add(typeof(IIdleMarkerGetter)            , "IDLA"       , nameof(IIdleMarkerGetter.Animations));
             Add(typeof(IIdleMarkerGetter)            , "IDLF"       , nameof(IIdleMarkerGetter.Flags));
             Add(typeof(IIdleMarkerGetter)            , "IDLT"       , nameof(IIdleMarkerGetter.IdleTimer));
+            Add(typeof(IImpactGetter)                , "DNAM"       , nameof(IImpactGetter.TextureSet));
+            Add(typeof(IImpactGetter)                , "ENAM"       , nameof(IImpactGetter.SecondaryTextureSet));
+            Add(typeof(IImpactGetter)                , "NAM1"       , nameof(IImpactGetter.Sound2));
+            Add(typeof(IImpactGetter)                , "NAM2"       , nameof(IImpactGetter.Hazard));
+            Add(typeof(IImpactGetter)                , "SNAM"       , nameof(IImpactGetter.Sound1));
+            Add(typeof(IIngestibleGetter)            , "DATA"       , nameof(IIngredientGetter.Weight));
             Add(typeof(IIngredientGetter)            , "ETYP"       , nameof(IIngredientGetter.EquipType));
+            Add(typeof(IKeywordGetter)               , "CNAM"       , nameof(IKeywordGetter.Color));
+            Add(typeof(ILightGetter)                 , "FNAM"       , nameof(ILightGetter.FadeValue));
+            Add(typeof(ILightGetter)                 , "LNAM"       , nameof(ILightGetter.Lens));
+            Add(typeof(ILightGetter)                 , "SNAM"       , nameof(ILightGetter.Sound));
+            Add(typeof(ILandscapeTextureGetter)      , "GNAM"       , nameof(ILandscapeTextureGetter.Grasses));
+            Add(typeof(ILandscapeTextureGetter)      , "MNAM"       , nameof(ILandscapeTextureGetter.MaterialType));
+            Add(typeof(ILandscapeTextureGetter)      , "SNAM"       , nameof(ILandscapeTextureGetter.TextureSpecularExponent));
+            Add(typeof(ILandscapeTextureGetter)      , "TNAM"       , nameof(ILandscapeTextureGetter.TextureSet));
+            Add(typeof(ILoadScreenGetter)            , "NNAM"       , nameof(ILoadScreenGetter.LoadingScreenNif));
+            Add(typeof(ILoadScreenGetter)            , "SNAM"       , nameof(ILoadScreenGetter.InitialScale));
+            Add(typeof(ILocationGetter)              , "CNAM"       , nameof(ILocationGetter.Color));
+            Add(typeof(ILocationGetter)              , "FNAM"       , nameof(ILocationGetter.UnreportedCrimeFaction));
+            Add(typeof(ILocationGetter)              , "MNAM"       , nameof(ILocationGetter.WorldLocationMarkerRef));
+            Add(typeof(ILocationGetter)              , "NAM0"       , nameof(ILocationGetter.HorseMarkerRef));
+            Add(typeof(ILocationGetter)              , "NAM1"       , nameof(ILocationGetter.Music));
+            Add(typeof(ILocationGetter)              , "PNAM"       , nameof(ILocationGetter.ParentLocation));
+            Add(typeof(ILocationGetter)              , "RNAM"       , nameof(ILocationGetter.WorldLocationRadius));
+            Add(typeof(ILocationReferenceTypeGetter) , "CNAM"       , nameof(ILocationReferenceTypeGetter.Color));
+            Add(typeof(IMagicEffectGetter)           , "DNAM"       , nameof(IMagicEffectGetter.Description));
+            Add(typeof(IMagicEffectGetter)           , "MDOB"       , nameof(IMagicEffectGetter.MenuDisplayObject));
+            Add(typeof(IMaterialTypeGetter)          , "BNAM"       , nameof(IMaterialTypeGetter.Buoyancy));
+            Add(typeof(IMaterialTypeGetter)          , "CNAM"       , nameof(IMaterialTypeGetter.HavokDisplayColor));
+            Add(typeof(IMaterialTypeGetter)          , "HNAM"       , nameof(IMaterialTypeGetter.HavokImpactDataSet));
+            Add(typeof(IMaterialTypeGetter)          , "PNAM"       , nameof(IMaterialTypeGetter.Parent));
+            Add(typeof(IMessageGetter)               , "QNAM"       , nameof(IMessageGetter.Quest));
+            Add(typeof(IMessageGetter)               , "TNAM"       , nameof(IMessageGetter.DisplayTime));
+            Add(typeof(IMoveableStaticGetter)        , "SNAM"       , nameof(IMoveableStaticGetter.LoopingSound));
+            Add(typeof(IMusicTrackGetter)            , "CNAM"       , nameof(IMusicTrackGetter.Type));
+            Add(typeof(IMusicTrackGetter)            , "DNAM"       , nameof(IMusicTrackGetter.FadeOut));
+            Add(typeof(IMusicTrackGetter)            , "FLTV"       , nameof(IMusicTrackGetter.Duration));
+            Add(typeof(IMusicTrackGetter)            , "SNAM"       , nameof(IMusicTrackGetter.Tracks));
+            Add(typeof(IMusicTypeGetter)             , "TNAM"       , nameof(IMusicTypeGetter.Tracks));
+            Add(typeof(IMusicTypeGetter)             , "WNAM"       , nameof(IMusicTypeGetter.FadeDuration));
             Add(typeof(INpcGetter)                   , "ANAM"       , nameof(INpcGetter.FarAwayModel));
             Add(typeof(INpcGetter)                   , "ATKR"       , nameof(INpcGetter.AttackRace));
             Add(typeof(INpcGetter)                   , "CNAM"       , nameof(INpcGetter.Class));
@@ -219,6 +268,8 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(INpcGetter)                   , "OCOR"       , nameof(INpcGetter.ObserveDeadBodyOverridePackageList));
             Add(typeof(INpcGetter)                   , "PKID"       , nameof(INpcGetter.Packages));
             Add(typeof(INpcGetter)                   , "PNAM"       , nameof(INpcGetter.HeadParts));
+            Add(typeof(INpcGetter)                   , "QNAM"       , nameof(INpcGetter.TextureLighting));
+            Add(typeof(INpcGetter)                   , "SNAM"       , nameof(INpcGetter.Factions));
             Add(typeof(INpcGetter)                   , "SOFT"       , nameof(INpcGetter.SleepingOutfit));
             Add(typeof(INpcGetter)                   , "SPLO"       , nameof(INpcGetter.ActorEffect));
             Add(typeof(INpcGetter)                   , "SPOR"       , nameof(INpcGetter.SpectatorOverridePackageList));
@@ -226,8 +277,68 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(INpcGetter)                   , "VTCK"       , nameof(INpcGetter.Voice));
             Add(typeof(INpcGetter)                   , "WNAM"       , nameof(INpcGetter.WornArmor));
             Add(typeof(INpcGetter)                   , "ZNAM"       , nameof(INpcGetter.CombatStyle));
+            Add(typeof(IPackageGetter)               , "CNAM"       , nameof(IPackageGetter.CombatStyle));
+            Add(typeof(IPackageGetter)               , "QNAM"       , nameof(IPackageGetter.OwnerQuest));
+            Add(typeof(IPackageGetter)               , "XNAM"       , nameof(IPackageGetter.XnamMarker));
+            Add(typeof(IPerkGetter)                  , "NNAM"       , nameof(IPerkGetter.NextPerk));
+            Add(typeof(IProjectileGetter)            , "VNAM"       , nameof(IProjectileGetter.SoundLevel));
+            Add(typeof(IQuestGetter)                 , "ANAM"       , nameof(IQuestGetter.NextAliasID));
+            Add(typeof(IQuestGetter)                 , "FLTR"       , nameof(IQuestGetter.Filter));
+            Add(typeof(IQuestGetter)                 , "QTGL"       , nameof(IQuestGetter.TextDisplayGlobals));
+            Add(typeof(IRaceGetter)                  , "ATKR"       , nameof(IRaceGetter.AttackRace));
+            Add(typeof(IRaceGetter)                  , "ENAM"       , nameof(IRaceGetter.Eyes));
+            Add(typeof(IRaceGetter)                  , "FLMV"       , nameof(IRaceGetter.BaseMovementDefaultFly));
+            Add(typeof(IRaceGetter)                  , "GNAM"       , nameof(IRaceGetter.BodyPartData));
+            Add(typeof(IRaceGetter)                  , "HNAM"       , nameof(IRaceGetter.Hairs));
+            Add(typeof(IRaceGetter)                  , "LNAM"       , nameof(IRaceGetter.CloseLootSound));
+            Add(typeof(IRaceGetter)                  , "NAM4"       , nameof(IRaceGetter.MaterialType));
+            Add(typeof(IRaceGetter)                  , "NAM5"       , nameof(IRaceGetter.ImpactDataSet));
+            Add(typeof(IRaceGetter)                  , "NAM7"       , nameof(IRaceGetter.DecapitationFX));
+            Add(typeof(IRaceGetter)                  , "NAM8"       , nameof(IRaceGetter.MorphRace));
+            Add(typeof(IRaceGetter)                  , "ONAM"       , nameof(IRaceGetter.OpenLootSound));
+            Add(typeof(IRaceGetter)                  , "PNAM"       , nameof(IRaceGetter.FacegenMainClamp));
+            Add(typeof(IRaceGetter)                  , "QNAM"       , nameof(IRaceGetter.EquipmentSlots));
+            Add(typeof(IRaceGetter)                  , "RNAM"       , nameof(IRaceGetter.ArmorRace));
+            Add(typeof(IRaceGetter)                  , "RNMV"       , nameof(IRaceGetter.BaseMovementDefaultRun));
+            Add(typeof(IRaceGetter)                  , "SNMV"       , nameof(IRaceGetter.BaseMovementDefaultSneak));
+            Add(typeof(IRaceGetter)                  , "SPMV"       , nameof(IRaceGetter.BaseMovementDefaultSprint));
+            Add(typeof(IRaceGetter)                  , "SWMV"       , nameof(IRaceGetter.BaseMovementDefaultSwim));
+            Add(typeof(IRaceGetter)                  , "UNAM"       , nameof(IRaceGetter.FacegenFaceClamp));
+            Add(typeof(IRaceGetter)                  , "UNES"       , nameof(IRaceGetter.UnarmedEquipSlot));
+            Add(typeof(IRaceGetter)                  , "VNAM"       , nameof(IRaceGetter.EquipmentFlags));
+            Add(typeof(IRaceGetter)                  , "WKMV"       , nameof(IRaceGetter.BaseMovementDefaultWalk));
+            Add(typeof(IRaceGetter)                  , "WNAM"       , nameof(IRaceGetter.Skin));
+            Add(typeof(IRegionGetter)                , "RCLR"       , nameof(IRegionGetter.MapColor));
+            Add(typeof(IRegionGetter)                , "WNAM"       , nameof(IRegionGetter.Worldspace));
+            Add(typeof(ISceneGetter)                 , "INAM"       , nameof(ISceneGetter.LastActionIndex));
+            Add(typeof(ISceneGetter)                 , "PNAM"       , nameof(ISceneGetter.Quest));
             Add(typeof(IScrollGetter)                , "MDOB"       , nameof(IScrollGetter.MenuDisplayObject));
+            Add(typeof(IShoutGetter)                 , "MDOB"       , nameof(IShoutGetter.MenuDisplayObject));
+            Add(typeof(ISoulGemGetter)               , "NAM0"       , nameof(ISoulGemGetter.LinkedTo));
+            Add(typeof(ISoulGemGetter)               , "SLCP"       , nameof(ISoulGemGetter.MaximumCapacity));
+            Add(typeof(ISoulGemGetter)               , "SOUL"       , nameof(ISoulGemGetter.ContainedSoul));
+            Add(typeof(ISoundCategoryGetter)         , "PNAM"       , nameof(ISoundCategoryGetter.Parent));
+            Add(typeof(ISoundCategoryGetter)         , "UNAM"       , nameof(ISoundCategoryGetter.DefaultMenuVolume));
+            Add(typeof(ISoundCategoryGetter)         , "VNAM"       , nameof(ISoundCategoryGetter.StaticVolumeMultiplier));
+            Add(typeof(ISoundDescriptorGetter)       , "CNAM"       , nameof(ISoundDescriptorGetter.Type));
+            Add(typeof(ISoundDescriptorGetter)       , "FNAM"       , nameof(ISoundDescriptorGetter.String));
+            Add(typeof(ISoundDescriptorGetter)       , "GNAM"       , nameof(ISoundDescriptorGetter.Category));
+            Add(typeof(ISoundDescriptorGetter)       , "ONAM"       , nameof(ISoundDescriptorGetter.OutputModel));
+            Add(typeof(ISoundDescriptorGetter)       , "SNAM"       , nameof(ISoundDescriptorGetter.AlternateSoundFor));
+            Add(typeof(ISoundMarkerGetter)           , "SDSC"       , nameof(ISoundMarkerGetter.SoundDescriptor));
+            Add(typeof(ISoundOutputModelGetter)      , "MNAM"       , nameof(ISoundOutputModelGetter.Type));
+            Add(typeof(ISpellGetter)                 , "MDOB"       , nameof(ISpellGetter.MenuDisplayObject));
+            Add(typeof(ITalkingActivatorGetter)      , "SNAM"       , nameof(ITalkingActivatorGetter.LoopingSound));
+            Add(typeof(ITalkingActivatorGetter)      , "VNAM"       , nameof(ITalkingActivatorGetter.VoiceType));
+            Add(typeof(ITreeGetter)                  , "PFIG"       , nameof(ITreeGetter.Ingredient));
+            Add(typeof(ITreeGetter)                  , "SNAM"       , nameof(ITreeGetter.HarvestSound));
+            Add(typeof(IWaterGetter)                 , "ANAM"       , nameof(IWaterGetter.Opacity));
+            Add(typeof(IWaterGetter)                 , "INAM"       , nameof(IWaterGetter.ImageSpace));
+            Add(typeof(IWaterGetter)                 , "SNAM"       , nameof(IWaterGetter.OpenSound));
+            Add(typeof(IWaterGetter)                 , "TNAM"       , nameof(IWaterGetter.Material));
+            Add(typeof(IWaterGetter)                 , "XNAM"       , nameof(IWaterGetter.Spell));
             Add(typeof(IWeaponGetter)                , "BIDS"       , nameof(IWeaponGetter.BlockBashImpact));
+            Add(typeof(IWeaponGetter)                , "CNAM"       , nameof(IWeaponGetter.Template));
             Add(typeof(IWeaponGetter)                , "INAM"       , nameof(IWeaponGetter.ImpactDataSet));
             Add(typeof(IWeaponGetter)                , "NAM7"       , nameof(IWeaponGetter.AttackLoopSound));
             Add(typeof(IWeaponGetter)                , "NAM8"       , nameof(IWeaponGetter.UnequipSound));
@@ -235,12 +346,19 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IWeaponGetter)                , "SNAM"       , nameof(IWeaponGetter.AttackSound));
             Add(typeof(IWeaponGetter)                , "TNAM"       , nameof(IWeaponGetter.AttackFailSound));
             Add(typeof(IWeaponGetter)                , "UNAM"       , nameof(IWeaponGetter.IdleSound));
+            Add(typeof(IWeaponGetter)                , "VNAM"       , nameof(IWeaponGetter.DetectionSoundLevel));
+            Add(typeof(IWeaponGetter)                , "WNAM"       , nameof(IWeaponGetter.FirstPersonModel));
             Add(typeof(IWeaponGetter)                , "XNAM"       , nameof(IWeaponGetter.AttackSound2D));
+            Add(typeof(IWeatherGetter)               , "GNAM"       , nameof(IWeatherGetter.SunGlareLensFlare));
+            Add(typeof(IWeatherGetter)               , "MNAM"       , nameof(IWeatherGetter.Precipitation));
+            Add(typeof(IWeatherGetter)               , "NNAM"       , nameof(IWeatherGetter.VisualEffect));
+            Add(typeof(IWordOfPowerGetter)           , "TNAM"       , nameof(IWordOfPowerGetter.Translation));
             Add(typeof(IWorldspaceGetter)            , "CNAM"       , nameof(IWorldspaceGetter.Climate));
             Add(typeof(IWorldspaceGetter)            , "LTMP"       , nameof(IWorldspaceGetter.InteriorLighting));
             Add(typeof(IWorldspaceGetter)            , "NAM3"       , nameof(IWorldspaceGetter.LodWater));
             Add(typeof(IWorldspaceGetter)            , "NAM4"       , nameof(IWorldspaceGetter.LodWaterHeight));
             Add(typeof(IWorldspaceGetter)            , "NAMA"       , nameof(IWorldspaceGetter.DistantLodMultiplier));
+            Add(typeof(IWorldspaceGetter)            , "OFST"       , nameof(IWorldspaceGetter.OffsetData));
             Add(typeof(IWorldspaceGetter)            , "ZNAM"       , nameof(IWorldspaceGetter.Music));
 #pragma warning restore format
         }
@@ -276,6 +394,7 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(ILightingTemplateGetter)      , "AmbientColor"                              , BasicAction<Color>.Instance);
             Add(typeof(IAcousticSpaceGetter)         , "AmbientSound"                              , FormLinkAction<ISoundDescriptorGetter>.Instance);
             Add(typeof(IEffectShaderGetter)          , "AmbientSound"                              , FormLinkAction<ISoundGetter>.Instance);
+            Add(typeof(IWeatherGetter)               , "ANAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(IImpactGetter)                , "AngleThreshold"                            , ConvertibleAction<float>.Instance);
             Add(typeof(IRaceGetter)                  , "AngularAccelerationRate"                   , ConvertibleAction<float>.Instance);
             Add(typeof(IRaceGetter)                  , "AngularTolerance"                          , ConvertibleAction<float>.Instance);
@@ -315,6 +434,7 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IEffectShaderGetter)          , "BirthPositionOffsetRangePlusMinus"         , ConvertibleAction<float>.Instance);
             Add(typeof(IClassGetter)                 , "BleedoutDefault"                           , ConvertibleAction<float>.Instance);
             Add(typeof(IWeaponGetter)                , "BlockBashImpact"                           , FormLinkAction<IImpactDataSetGetter>.Instance);
+            Add(typeof(IWeatherGetter)               , "BNAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(IRaceGetter)                  , "BodyBipedObject"                           , EnumsAction.Instance);
             Add(typeof(IRaceGetter)                  , "BodyPartData"                              , FormLinkAction<IBodyPartDataGetter>.Instance);
             Add(typeof(IBookGetter)                  , "BookText"                                  , ConvertibleAction<string>.Instance);
@@ -342,6 +462,7 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IRaceGetter)                  , "CloseLootSound"                            , FormLinkAction<ISoundDescriptorGetter>.Instance);
             Add(typeof(IContainerGetter)             , "CloseSound"                                , FormLinkAction<ISoundDescriptorGetter>.Instance);
             Add(typeof(IDoorGetter)                  , "CloseSound"                                , FormLinkAction<ISoundDescriptorGetter>.Instance);
+            Add(null                                 , "CNAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(ICollisionLayerGetter)        , "CollidesWith"                              , FormLinksAction<ICollisionLayerGetter>.Instance);
             Add(typeof(IProjectileGetter)            , "CollisionLayer"                            , FormLinkAction<ICollisionLayerGetter>.Instance);
             Add(typeof(IProjectileGetter)            , "CollisionRadius"                           , ConvertibleAction<float>.Instance);
@@ -370,6 +491,7 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IConstructibleObjectGetter)   , "CreatedObjectCount"                        , ConvertibleAction<ushort>.Instance);
             Add(typeof(INpcGetter)                   , "CrimeFaction"                              , FormLinkAction<IFactionGetter>.Instance);
             Add(typeof(ICombatStyleGetter)           , "CSGDDataTypeState"                         , FlagsAction.Instance);
+            Add(typeof(ICombatStyleGetter)           , "CSMD"                                      , MemorySliceByteAction.Instance);
             Add(typeof(IAmmunitionGetter)            , "Damage"                                    , ConvertibleAction<float>.Instance);
             Add(typeof(IExplosionGetter)             , "Damage"                                    , ConvertibleAction<float>.Instance);
             Add(typeof(IWaterGetter)                 , "DamagePerSecond"                           , ConvertibleAction<ushort>.Instance);
@@ -410,6 +532,8 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IWaterGetter)                 , "DisplacementVelocity"                      , ConvertibleAction<float>.Instance);
             Add(typeof(IMessageGetter)               , "DisplayTime"                               , ConvertibleAction<uint>.Instance);
             Add(typeof(IWorldspaceGetter)            , "DistantLodMultiplier"                      , ConvertibleAction<float>.Instance);
+            Add(typeof(IDialogViewGetter)            , "DNAM"                                      , MemorySliceByteAction.Instance);
+            Add(typeof(IWeatherGetter)               , "DNAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(IStaticGetter)                , "DNAMDataTypeState"                         , FlagsAction.Instance);
             Add(typeof(IWaterGetter)                 , "DNAMDataTypeState"                         , FlagsAction.Instance);
             Add(typeof(IMagicEffectGetter)           , "DualCastArt"                               , FormLinkAction<IDualCastDataGetter>.Instance);
@@ -426,9 +550,12 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IEffectShaderGetter)          , "EdgeEffectFullAlphaTime"                   , ConvertibleAction<float>.Instance);
             Add(typeof(IEffectShaderGetter)          , "EdgeEffectPersistentAlphaRatio"            , ConvertibleAction<float>.Instance);
             Add(typeof(IEffectShaderGetter)          , "EdgeWidth"                                 , ConvertibleAction<float>.Instance);
+            Add(null                                 , "EditorID"                                  , ConvertibleAction<string>.Instance);
             Add(typeof(IVisualEffectGetter)          , "EffectArt"                                 , FormLinkAction<IArtObjectGetter>.Instance);
             Add(null                                 , "Effects"                                   , EffectsAction.Instance);
             Add(typeof(IDualCastDataGetter)          , "EffectShader"                              , FormLinkAction<IEffectShaderGetter>.Instance);
+            Add(typeof(IDialogViewGetter)            , "ENAM"                                      , MemorySliceByteAction.Instance);
+            Add(typeof(IImageSpaceGetter)            , "ENAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(IMagicEffectGetter)           , "EnchantArt"                                , FormLinkAction<IArtObjectGetter>.Instance);
             Add(typeof(IArmorGetter)                 , "EnchantmentAmount"                         , ConvertibleAction<ushort>.Instance);
             Add(typeof(IObjectEffectGetter)          , "EnchantmentAmount"                         , ConvertibleAction<int>.Instance);
@@ -504,6 +631,7 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(ILightGetter)                 , "FlickerPeriod"                             , ConvertibleAction<float>.Instance);
             Add(typeof(IRaceGetter)                  , "FlightRadius"                              , ConvertibleAction<float>.Instance);
             Add(typeof(ITalkingActivatorGetter)      , "FNAM"                                      , ConvertibleAction<short>.Instance);
+            Add(null                                 , "FNAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(IWaterGetter)                 , "FogAboveWaterAmount"                       , ConvertibleAction<float>.Instance);
             Add(typeof(IWaterGetter)                 , "FogAboveWaterDistanceFarPlane"             , ConvertibleAction<float>.Instance);
             Add(typeof(IWaterGetter)                 , "FogAboveWaterDistanceNearPlane"            , ConvertibleAction<float>.Instance);
@@ -528,12 +656,14 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IFactionGetter)               , "FollowerWaitMarker"                        , FormLinkAction<IPlacedObjectGetter>.Instance);
             Add(typeof(IArmorAddonGetter)            , "FootstepSound"                             , FormLinkAction<IFootstepSetGetter>.Instance);
             Add(typeof(IExplosionGetter)             , "Force"                                     , ConvertibleAction<float>.Instance);
+            Add(null                                 , "FormVersion"                               , ConvertibleAction<ushort>.Instance);
             Add(typeof(IMovementTypeGetter)          , "ForwardRun"                                , ConvertibleAction<float>.Instance);
             Add(typeof(IMovementTypeGetter)          , "ForwardWalk"                               , ConvertibleAction<float>.Instance);
             Add(typeof(ILightGetter)                 , "FOV"                                       , ConvertibleAction<float>.Instance);
             Add(typeof(INpcGetter)                   , "GiftFilter"                                , FormLinkAction<IFormListGetter>.Instance);
             Add(typeof(ILeveledItemGetter)           , "Global"                                    , FormLinkAction<IGlobalGetter>.Instance);
             Add(typeof(ILeveledNpcGetter)            , "Global"                                    , FormLinkAction<IGlobalGetter>.Instance);
+            Add(typeof(IWaterGetter)                 , "GNAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(ILandscapeTextureGetter)      , "Grasses"                                   , FormLinksAction<IGrassGetter>.Instance);
             Add(typeof(IProjectileGetter)            , "Gravity"                                   , ConvertibleAction<float>.Instance);
             Add(typeof(IShaderParticleGeometryGetter), "GravityVelocity"                           , ConvertibleAction<float>.Instance);
@@ -578,6 +708,7 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IMagicEffectGetter)           , "ImpactData"                                , FormLinkAction<IImpactDataSetGetter>.Instance);
             Add(null                                 , "ImpactDataSet"                             , FormLinkAction<IImpactDataSetGetter>.Instance);
             Add(typeof(IProjectileGetter)            , "ImpactForce"                               , ConvertibleAction<float>.Instance);
+            Add(typeof(IMessageGetter)               , "INAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(ICollisionLayerGetter)        , "Index"                                     , ConvertibleAction<uint>.Instance);
             Add(typeof(IFloraGetter)                 , "Ingredient"                                , FormLinkAction<IHarvestTargetGetter>.Instance);
             Add(typeof(ITreeGetter)                  , "Ingredient"                                , FormLinkAction<IHarvestTargetGetter>.Instance);
@@ -615,6 +746,8 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IWeatherGetter)               , "LightningColor"                            , BasicAction<Color>.Instance);
             Add(typeof(IHazardGetter)                , "Limit"                                     , ConvertibleAction<uint>.Instance);
             Add(typeof(ISoulGemGetter)               , "LinkedTo"                                  , FormLinkAction<ISoulGemGetter>.Instance);
+            Add(typeof(ICellGetter)                  , "LNAM"                                      , MemorySliceByteAction.Instance);
+            Add(typeof(IWeatherGetter)               , "LNAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(ILoadScreenGetter)            , "LoadingScreenNif"                          , FormLinkAction<IStaticGetter>.Instance);
             Add(typeof(ICameraShotGetter)            , "Location"                                  , EnumsAction.Instance);
             Add(null                                 , "Location"                                  , FormLinkAction<ILocationGetter>.Instance);
@@ -655,12 +788,15 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IEncounterZoneGetter)         , "MinLevel"                                  , ConvertibleAction<sbyte>.Instance);
             Add(typeof(IGrassGetter)                 , "MinSlope"                                  , ConvertibleAction<byte>.Instance);
             Add(typeof(ICameraShotGetter)            , "MinTime"                                   , ConvertibleAction<float>.Instance);
+            Add(typeof(IWaterGetter)                 , "MNAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(IClimateGetter)               , "Moons"                                     , FlagsAction.Instance);
             Add(typeof(IRaceGetter)                  , "MorphRace"                                 , FormLinkAction<IRaceGetter>.Instance);
             Add(null                                 , "Music"                                     , FormLinkAction<IMusicTypeGetter>.Instance);
             Add(typeof(IProjectileGetter)            , "MuzzleFlash"                               , FormLinkAction<ILightGetter>.Instance);
             Add(typeof(IProjectileGetter)            , "MuzzleFlashDuration"                       , ConvertibleAction<float>.Instance);
             Add(typeof(IWeatherGetter)               , "NAM0DataTypeState"                         , FlagsAction.Instance);
+            Add(typeof(IWeatherGetter)               , "NAM2"                                      , MemorySliceByteAction.Instance);
+            Add(typeof(IWeatherGetter)               , "NAM3"                                      , MemorySliceByteAction.Instance);
             Add(typeof(INpcGetter)                   , "NAM5"                                      , ConvertibleAction<ushort>.Instance);
             Add(null                                 , "Name"                                      , ConvertibleAction<string>.Instance);
             Add(typeof(ILightGetter)                 , "NearClip"                                  , ConvertibleAction<float>.Instance);
@@ -689,10 +825,13 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IPerkGetter)                  , "NumRanks"                                  , ConvertibleAction<byte>.Instance);
             Add(typeof(IShaderParticleGeometryGetter), "NumSubtexturesX"                           , ConvertibleAction<uint>.Instance);
             Add(typeof(IShaderParticleGeometryGetter), "NumSubtexturesY"                           , ConvertibleAction<uint>.Instance);
-            Add(null                                 , "ObjectBounds"                              , DeepCopyAction<IObjectBoundsGetter>.Instance);
+            Add(null                                 , "ObjectBounds"                              , ObjectBoundsAction.Instance);
             Add(null                                 , "ObjectEffect"                              , FormLinkAction<IEffectRecordGetter>.Instance);
             Add(typeof(INpcGetter)                   , "ObserveDeadBodyOverridePackageList"        , FormLinkAction<IFormListGetter>.Instance);
+            Add(typeof(ICellGetter)                  , "OcclusionData"                             , MemorySliceByteAction.Instance);
             Add(typeof(ICombatStyleGetter)           , "OffensiveMult"                             , ConvertibleAction<float>.Instance);
+            Add(typeof(IWorldspaceGetter)            , "OffsetData"                                , MemorySliceByteAction.Instance);
+            Add(typeof(IWeatherGetter)               , "ONAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(IWaterGetter)                 , "Opacity"                                   , ConvertibleAction<byte>.Instance);
             Add(typeof(IRaceGetter)                  , "OpenLootSound"                             , FormLinkAction<ISoundDescriptorGetter>.Instance);
             Add(null                                 , "OpenSound"                                 , FormLinkAction<ISoundDescriptorGetter>.Instance);
@@ -756,6 +895,8 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IPerkGetter)                  , "Playable"                                  , ConvertibleAction<bool>.Instance);
             Add(typeof(IFactionGetter)               , "PlayerInventoryContainer"                  , FormLinkAction<IPlacedObjectGetter>.Instance);
             Add(typeof(INpcGetter)                   , "PlayerSkills"                              , PlayerSkillsAction.Instance);
+            Add(typeof(IFloraGetter)                 , "PNAM"                                      , MemorySliceByteAction.Instance);
+            Add(typeof(IFurnitureGetter)             , "PNAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(ITalkingActivatorGetter)      , "PNAM"                                      , ConvertibleAction<int>.Instance);
             Add(typeof(IGrassGetter)                 , "PositionRange"                             , ConvertibleAction<float>.Instance);
             Add(typeof(IWeatherGetter)               , "Precipitation"                             , FormLinkAction<IShaderParticleGeometryGetter>.Instance);
@@ -829,9 +970,12 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IMagicEffectGetter)           , "SkillUsageMultiplier"                      , ConvertibleAction<float>.Instance);
             Add(typeof(IRaceGetter)                  , "Skin"                                      , FormLinkAction<IArmorGetter>.Instance);
             Add(typeof(ICellGetter)                  , "SkyAndWeatherFromRegion"                   , FormLinkAction<IRegionGetter>.Instance);
+            Add(null                                 , "SkyrimMajorRecordFlags"                    , FlagsAction.Instance);
             Add(typeof(IWeatherGetter)               , "SkyStatics"                                , FormLinksAction<IStaticGetter>.Instance);
             Add(typeof(INpcGetter)                   , "SleepingOutfit"                            , FormLinkAction<IOutfitGetter>.Instance);
             Add(typeof(IEquipTypeGetter)             , "SlotParents"                               , FormLinksAction<IEquipTypeGetter>.Instance);
+            Add(typeof(ISoundOutputModelGetter)      , "SNAM"                                      , MemorySliceByteAction.Instance);
+            Add(typeof(ISoundMarkerGetter)           , "SNDD"                                      , MemorySliceByteAction.Instance);
             Add(null                                 , "Sound"                                     , FormLinkAction<ISoundDescriptorGetter>.Instance);
             Add(typeof(IExplosionGetter)             , "Sound1"                                    , FormLinkAction<ISoundDescriptorGetter>.Instance);
             Add(typeof(IImpactGetter)                , "Sound1"                                    , FormLinkAction<ISoundGetter>.Instance);
@@ -879,6 +1023,7 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IQuestGetter)                 , "TextDisplayGlobals"                        , FormLinksAction<IGlobalGetter>.Instance);
             Add(typeof(IEffectShaderGetter)          , "TextureCountU"                             , ConvertibleAction<uint>.Instance);
             Add(typeof(IEffectShaderGetter)          , "TextureCountV"                             , ConvertibleAction<uint>.Instance);
+            Add(typeof(IProjectileGetter)            , "TextureFilesHashes"                        , MemorySliceByteAction.Instance);
             Add(typeof(INpcGetter)                   , "TextureLighting"                           , BasicAction<Color>.Instance);
             Add(null                                 , "TextureSet"                                , FormLinkAction<ITextureSetGetter>.Instance);
             Add(typeof(ILandscapeTextureGetter)      , "TextureSpecularExponent"                   , ConvertibleAction<byte>.Instance);
@@ -899,7 +1044,6 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(ITreeGetter)                  , "TrunkFlexibility"                          , ConvertibleAction<float>.Instance);
             Add(typeof(IArtObjectGetter)             , "Type"                                      , FlagsAction.Instance);
             Add(null                                 , "Type"                                      , EnumsAction.Instance);
-            Add(typeof(IGlobalGetter)                , "TypeChar"                                  , ConvertibleAction<char>.Instance);
             Add(typeof(IRaceGetter)                  , "UnarmedDamage"                             , ConvertibleAction<float>.Instance);
             Add(typeof(IRaceGetter)                  , "UnarmedEquipSlot"                          , FormLinkAction<IEquipTypeGetter>.Instance);
             Add(typeof(IRaceGetter)                  , "UnarmedReach"                              , ConvertibleAction<float>.Instance);
@@ -919,6 +1063,7 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IWeatherGetter)               , "VisualEffect"                              , FormLinkAction<IVisualEffectGetter>.Instance);
             Add(typeof(IWeatherGetter)               , "VisualEffectBegin"                         , BasicAction<Percent>.Instance);
             Add(typeof(IWeatherGetter)               , "VisualEffectEnd"                           , BasicAction<Percent>.Instance);
+            Add(typeof(ISceneGetter)                 , "VNAM"                                      , MemorySliceByteAction.Instance);
             Add(typeof(INpcGetter)                   , "Voice"                                     , FormLinkAction<IVoiceTypeGetter>.Instance);
             Add(typeof(IClassGetter)                 , "VoicePoints"                               , ConvertibleAction<uint>.Instance);
             Add(typeof(ITalkingActivatorGetter)      , "VoiceType"                                 , FormLinkAction<IVoiceTypeGetter>.Instance);
@@ -949,6 +1094,9 @@ namespace GenericSynthesisPatcher.Helpers
             Add(typeof(IRegionGetter)                , "Worldspace"                                , FormLinkAction<IWorldspaceGetter>.Instance);
             Add(typeof(INpcGetter)                   , "WornArmor"                                 , FormLinkAction<IArmorGetter>.Instance);
             Add(typeof(IObjectEffectGetter)          , "WornRestrictions"                          , FormLinkAction<IFormListGetter>.Instance);
+            Add(typeof(IPackageGetter)               , "XnamMarker"                                , MemorySliceByteAction.Instance);
+            Add(typeof(ICellGetter)                  , "XWCN"                                      , MemorySliceByteAction.Instance);
+            Add(typeof(ICellGetter)                  , "XWCS"                                      , MemorySliceByteAction.Instance);
             Add(typeof(ICameraPathGetter)            , "Zoom"                                      , FlagsAction.Instance);
             Add(typeof(ICameraPathGetter)            , "ZoomMustHaveCameraShots"                   , ConvertibleAction<bool>.Instance);
             #pragma warning restore format
@@ -976,13 +1124,13 @@ namespace GenericSynthesisPatcher.Helpers
 
     internal readonly struct RecordProperty (Type? type, string propertyName) : IRecordProperty
     {
-        public string PropertyName { get; } = propertyName;
-
-        public Type? Type { get; } = type;
-
         public RecordProperty (string propertyName) : this(null, propertyName)
         {
         }
+
+        public string PropertyName { get; } = propertyName;
+
+        public Type? Type { get; } = type;
     }
 
     internal class RecordPropertyComparer : IEqualityComparer<IRecordProperty>

--- a/GenericSynthesisPatcher/Json/Converters/MemorySliceByteConverter.cs
+++ b/GenericSynthesisPatcher/Json/Converters/MemorySliceByteConverter.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+
+using Noggog;
+
+namespace GenericSynthesisPatcher.Json.Converters
+{
+    public class MemorySliceByteConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+
+        public override bool CanConvert (Type objectType) => objectType == typeof(MemorySlice<byte>);
+
+        public override object? ReadJson (JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonToken.StartArray:
+                    var data = serializer.Deserialize<List<byte>>(reader) ?? throw new JsonSerializationException("Unable to read byte array.");
+
+                    return new MemorySlice<byte>([.. data]);
+            }
+
+            throw new JsonSerializationException("Unable to read byte array.");
+        }
+
+        public override void WriteJson (JsonWriter writer, object? value, JsonSerializer serializer) => throw new NotImplementedException();
+    }
+}

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -16,389 +16,511 @@ This just details where the field can currently be used.
 
 ## ASPC - AcousticSpace
 
-| Field              | Alt  | MFFSM | Value Type                                               | Example                       |
-| ------------------ | ---- | ----- | -------------------------------------------------------- | ----------------------------- |
-| AmbientSound       | SNAM | MFF-- | Form Key or Editor ID                                    |                               |
-| EnvironmentType    | BNAM | MFF-- | Form Key or Editor ID                                    |                               |
-| ObjectBounds       | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9] |
-| UseSoundFromRegion | RDAT | MFF-- | Form Key or Editor ID                                    |                               |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AmbientSound           | SNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| EnvironmentType        | BNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| ObjectBounds           | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| UseSoundFromRegion     | RDAT | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
 
 [⬅ Back to Types](Types.md)
 
 ## AACT - ActionRecord
 
-| Field | Alt  | MFFSM | Value Type                                                                                                                                                                                                  | Example             |
-| ----- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| Color | CNAM | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60] |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                                    | Example                                          |
+| ---------------------- | ---- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Color                  | CNAM | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60]                              |
+| EditorID               | EDID | MFF-- | String value                                                                                                                                                  | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                                                 | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)                     | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## ACTI - Activator
 
-| Field                | Alt            | MFFSM | Value Type                                                                                                                                  | Example                                                    |
-| -------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| ActivateTextOverride | RNAM           | MFF-- | String value                                                                                                                                | "ActivateTextOverride": "Hello"                            |
-| ActivationSound      | VNAM           | MFF-- | Form Key or Editor ID                                                                                                                       |                                                            |
-| Flags                | DataFlags;FNAM | MF--- | Flags (NoDisplacement, IgnoredBySandbox)                                                                                                    | "Flags": [ "NoDisplacement", "-IgnoredBySandbox" ]         |
-| InteractionKeyword   | KNAM           | MFF-- | Form Key or Editor ID                                                                                                                       |                                                            |
-| Keywords             | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                                                     |                                                            |
-| LoopingSound         | SNAM           | MFF-- | Form Key or Editor ID                                                                                                                       |                                                            |
-| MajorFlags           | RecordFlags    | MF--- | Flags (HasTreeLOD, MustUpdateAnims, HiddenFromLocalMap, HasDistantLOD, RandomAnimStart, Dangerous, IgnoreObjectInteraction, IsMarker, Obstacle, NavMeshGenerationFilter, NavMeshGenerationBoundingBox, ChildCanUse, NavMeshGenerationGround) | "MajorFlags": [ "HasTreeLOD", "-NavMeshGenerationGround" ] |
-| MarkerColor          | PNAM           | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "MarkerColor": [40,50,60]                                  |
-| Name                 | FULL           | MFF-- | String value                                                                                                                                | "Name": "Hello"                                            |
-| ObjectBounds         | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                    | "ObjectBounds": [6,6,6,9,9,9]                              |
-| WaterType            | WNAM           | MFF-- | Form Key or Editor ID                                                                                                                       |                                                            |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                                    |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| ActivateTextOverride   | RNAM           | MFF-- | String value                                                                                                                              | "ActivateTextOverride": "Hello"                            |
+| ActivationSound        | VNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                            |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                        |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (NoDisplacement, IgnoredBySandbox)                                                                                                  | "Flags": [ "NoDisplacement", "-IgnoredBySandbox" ]         |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                           |
+| InteractionKeyword     | KNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                            |
+| Keywords               | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                            |
+| LoopingSound           | SNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                            |
+| MajorFlags             | RecordFlags    | MF--- | Flags (HasTreeLOD, MustUpdateAnims, HiddenFromLocalMap, HasDistantLOD, RandomAnimStart, Dangerous, IgnoreObjectInteraction, IsMarker, Obstacle, NavMeshGenerationFilter, NavMeshGenerationBoundingBox, ChildCanUse, NavMeshGenerationGround) | "MajorFlags": [ "HasTreeLOD", "-NavMeshGenerationGround" ] |
+| MarkerColor            | PNAM           | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "MarkerColor": [40,50,60]                                  |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                            |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                              |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]           |
+| WaterType              | WNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                            |
 
 [⬅ Back to Types](Types.md)
 
 ## AVIF - ActorValueInformation
 
-| Field        | Alt  | MFFSM | Value Type   | Example                 |
-| ------------ | ---- | ----- | ------------ | ----------------------- |
-| Abbreviation | ANAM | MFF-- | String value | "Abbreviation": "Hello" |
-| Description  | DESC | MFF-- | String value | "Description": "Hello"  |
-| Name         | FULL | MFF-- | String value | "Name": "Hello"         |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Abbreviation           | ANAM | MFF-- | String value                                                                                                                              | "Abbreviation": "Hello"                          |
+| CNAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| Description            | DESC | MFF-- | String value                                                                                                                              | "Description": "Hello"                           |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Name                   | FULL | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## ADDN - AddonNode
 
-| Field                   | Alt  | MFFSM | Value Type                                               | Example                       |
-| ----------------------- | ---- | ----- | -------------------------------------------------------- | ----------------------------- |
-| AlwaysLoaded            |      | MFF-- | True / False                                             | "AlwaysLoaded": true          |
-| MasterParticleSystemCap |      | MFF-- | Numeric value                                            | "MasterParticleSystemCap": 7  |
-| NodeIndex               | DATA | MFF-- | Numeric value                                            | "NodeIndex": 7                |
-| ObjectBounds            | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9] |
-| Sound                   | SNAM | MFF-- | Form Key or Editor ID                                    |                               |
+| Field                   | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ----------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AlwaysLoaded            |      | MFF-- | True / False                                                                                                                              | "AlwaysLoaded": true                             |
+| EditorID                | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion             |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| MasterParticleSystemCap |      | MFF-- | Numeric value                                                                                                                             | "MasterParticleSystemCap": 7                     |
+| NodeIndex               | DATA | MFF-- | Numeric value                                                                                                                             | "NodeIndex": 7                                   |
+| ObjectBounds            | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| SkyrimMajorRecordFlags  |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Sound                   | SNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
 
 [⬅ Back to Types](Types.md)
 
 ## APPA - AlchemicalApparatus
 
-| Field        | Alt  | MFFSM | Value Type                                                       | Example                       |
-| ------------ | ---- | ----- | ---------------------------------------------------------------- | ----------------------------- |
-| Description  | DESC | MFF-- | String value                                                     | "Description": "Hello"        |
-| Name         | FULL | MFF-- | String value                                                     | "Name": "Hello"               |
-| ObjectBounds | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]         | "ObjectBounds": [6,6,6,9,9,9] |
-| PickUpSound  | YNAM | MFF-- | Form Key or Editor ID                                            |                               |
-| PutDownSound | ZNAM | MFF-- | Form Key or Editor ID                                            |                               |
-| Quality      | QUAL | MF--- | Possible values (Novice, Apprentice, Journeyman, Expert, Master) | "Quality": "Novice"           |
-| Value        |      | MFF-- | Numeric value                                                    | "Value": 7                    |
-| Weight       |      | MFF-- | Decimal value                                                    | "Weight": 3.14                |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Description            | DESC | MFF-- | String value                                                                                                                              | "Description": "Hello"                           |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Name                   | FULL | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| ObjectBounds           | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| PickUpSound            | YNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PutDownSound           | ZNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Quality                | QUAL | MF--- | Possible values (Novice, Apprentice, Journeyman, Expert, Master)                                                                          | "Quality": "Novice"                              |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Value                  |      | MFF-- | Numeric value                                                                                                                             | "Value": 7                                       |
+| Weight                 |      | MFF-- | Decimal value                                                                                                                             | "Weight": 3.14                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## AMMO - Ammunition
 
-| Field        | Alt            | MFFSM | Value Type                                                  | Example                                                  |
-| ------------ | -------------- | ----- | ----------------------------------------------------------- | -------------------------------------------------------- |
-| Damage       | DMG            | MFF-- | Decimal value                                               | "Damage": 3.14                                           |
-| Description  | DESC           | MFF-- | String value                                                | "Description": "Hello"                                   |
-| Flags        | DataFlags;FNAM | MF--- | Flags (IgnoresNormalWeaponResistance, NonPlayable, NonBolt) | "Flags": [ "IgnoresNormalWeaponResistance", "-NonBolt" ] |
-| Keywords     | KWDA           | MFFSM | Form Keys or Editor IDs                                     |                                                          |
-| MajorFlags   | RecordFlags    | MF--- | Flags (NonPlayable)                                         | "MajorFlags": "NonPlayable"                              |
-| Name         | FULL           | MFF-- | String value                                                | "Name": "Hello"                                          |
-| ObjectBounds | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]    | "ObjectBounds": [6,6,6,9,9,9]                            |
-| PickUpSound  | YNAM           | MFF-- | Form Key or Editor ID                                       |                                                          |
-| Projectile   |                | MFF-- | Form Key or Editor ID                                       |                                                          |
-| PutDownSound | ZNAM           | MFF-- | Form Key or Editor ID                                       |                                                          |
-| ShortName    | ONAM           | MFF-- | String value                                                | "ShortName": "Hello"                                     |
-| Value        |                | MFF-- | Numeric value                                               | "Value": 7                                               |
-| Weight       |                | MFF-- | Decimal value                                               | "Weight": 3.14                                           |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                                  |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Damage                 | DMG            | MFF-- | Decimal value                                                                                                                             | "Damage": 3.14                                           |
+| Description            | DESC           | MFF-- | String value                                                                                                                              | "Description": "Hello"                                   |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                      |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (IgnoresNormalWeaponResistance, NonPlayable, NonBolt)                                                                               | "Flags": [ "IgnoresNormalWeaponResistance", "-NonBolt" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                         |
+| Keywords               | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                          |
+| MajorFlags             | RecordFlags    | MF--- | Flags (NonPlayable)                                                                                                                       | "MajorFlags": "NonPlayable"                              |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                          |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                            |
+| PickUpSound            | YNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                          |
+| Projectile             |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                          |
+| PutDownSound           | ZNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                          |
+| ShortName              | ONAM           | MFF-- | String value                                                                                                                              | "ShortName": "Hello"                                     |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]         |
+| Value                  |                | MFF-- | Numeric value                                                                                                                             | "Value": 7                                               |
+| Weight                 |                | MFF-- | Decimal value                                                                                                                             | "Weight": 3.14                                           |
 
 [⬅ Back to Types](Types.md)
 
 ## ANIO - AnimatedObject
 
-| Field       | Alt  | MFFSM | Value Type   | Example                |
-| ----------- | ---- | ----- | ------------ | ---------------------- |
-| UnloadEvent | BNAM | MFF-- | String value | "UnloadEvent": "Hello" |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| UnloadEvent            | BNAM | MFF-- | String value                                                                                                                              | "UnloadEvent": "Hello"                           |
 
 [⬅ Back to Types](Types.md)
 
 ## ARMA - ArmorAddon
 
-| Field               | Alt  | MFFSM | Value Type              | Example                  |
-| ------------------- | ---- | ----- | ----------------------- | ------------------------ |
-| AdditionalRaces     | MODL | MFFSM | Form Keys or Editor IDs |                          |
-| ArtObject           | ONAM | MFF-- | Form Key or Editor ID   |                          |
-| DetectionSoundValue |      | MFF-- | Numeric value           | "DetectionSoundValue": 7 |
-| FootstepSound       | SNDD | MFF-- | Form Key or Editor ID   |                          |
-| Race                | RNAM | MFF-- | Form Key or Editor ID   |                          |
-| WeaponAdjust        |      | MFF-- | Decimal value           | "WeaponAdjust": 3.14     |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AdditionalRaces        | MODL | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| ArtObject              | ONAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| DetectionSoundValue    |      | MFF-- | Numeric value                                                                                                                             | "DetectionSoundValue": 7                         |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FootstepSound          | SNDD | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Race                   | RNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| WeaponAdjust           |      | MFF-- | Decimal value                                                                                                                             | "WeaponAdjust": 3.14                             |
 
 [⬅ Back to Types](Types.md)
 
 ## ARMO - Armor
 
-| Field                     | Alt         | MFFSM | Value Type                                               | Example                                    |
-| ------------------------- | ----------- | ----- | -------------------------------------------------------- | ------------------------------------------ |
-| AlternateBlockMaterial    | BAMT        | MFF-- | Form Key or Editor ID                                    |                                            |
-| Armature                  | MODL        | MFFSM | Form Keys or Editor IDs                                  |                                            |
-| ArmorRating               | DNAM        | MFF-- | Decimal value                                            | "ArmorRating": 3.14                        |
-| BashImpactDataSet         | BIDS        | MFF-- | Form Key or Editor ID                                    |                                            |
-| Description               | DESC        | MFF-- | String value                                             | "Description": "Hello"                     |
-| EnchantmentAmount         | EAMT        | MFF-- | Numeric value                                            | "EnchantmentAmount": 7                     |
-| EquipmentType             | ETYP        | MFF-- | Form Key or Editor ID                                    |                                            |
-| Keywords                  | KWDA        | MFFSM | Form Keys or Editor IDs                                  |                                            |
-| MajorFlags                | RecordFlags | MF--- | Flags (NonPlayable, Shield)                              | "MajorFlags": [ "NonPlayable", "-Shield" ] |
-| Name                      | FULL        | MFF-- | String value                                             | "Name": "Hello"                            |
-| ObjectBounds              | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9]              |
-| ObjectEffect              | EITM        | MFF-- | Form Key or Editor ID                                    |                                            |
-| PickUpSound               | YNAM        | MFF-- | Form Key or Editor ID                                    |                                            |
-| PutDownSound              | ZNAM        | MFF-- | Form Key or Editor ID                                    |                                            |
-| Race                      | RNAM        | MFF-- | Form Key or Editor ID                                    |                                            |
-| RagdollConstraintTemplate | BMCT        | MFF-- | String value                                             | "RagdollConstraintTemplate": "Hello"       |
-| TemplateArmor             | TNAM        | MFF-- | Form Key or Editor ID                                    |                                            |
-| Value                     |             | MFF-- | Numeric value                                            | "Value": 7                                 |
-| Weight                    |             | MFF-- | Decimal value                                            | "Weight": 3.14                             |
+| Field                     | Alt         | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ------------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AlternateBlockMaterial    | BAMT        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Armature                  | MODL        | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| ArmorRating               | DNAM        | MFF-- | Decimal value                                                                                                                             | "ArmorRating": 3.14                              |
+| BashImpactDataSet         | BIDS        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Description               | DESC        | MFF-- | String value                                                                                                                              | "Description": "Hello"                           |
+| EditorID                  | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| EnchantmentAmount         | EAMT        | MFF-- | Numeric value                                                                                                                             | "EnchantmentAmount": 7                           |
+| EquipmentType             | ETYP        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| FormVersion               |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Keywords                  | KWDA        | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| MajorFlags                | RecordFlags | MF--- | Flags (NonPlayable, Shield)                                                                                                               | "MajorFlags": [ "NonPlayable", "-Shield" ]       |
+| Name                      | FULL        | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| ObjectBounds              | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| ObjectEffect              | EITM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PickUpSound               | YNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PutDownSound              | ZNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Race                      | RNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| RagdollConstraintTemplate | BMCT        | MFF-- | String value                                                                                                                              | "RagdollConstraintTemplate": "Hello"             |
+| SkyrimMajorRecordFlags    |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| TemplateArmor             | TNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Value                     |             | MFF-- | Numeric value                                                                                                                             | "Value": 7                                       |
+| Weight                    |             | MFF-- | Decimal value                                                                                                                             | "Weight": 3.14                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## ARTO - ArtObject
 
-| Field        | Alt  | MFFSM | Value Type                                               | Example                                          |
-| ------------ | ---- | ----- | -------------------------------------------------------- | ------------------------------------------------ |
-| ObjectBounds | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9]                    |
-| Type         | DNAM | MF--- | Flags (MagicCasting, MagicHitEffect, EnchantmentEffect)  | "Type": [ "MagicCasting", "-EnchantmentEffect" ] |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| ObjectBounds           | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Type                   | DNAM | MF--- | Flags (MagicCasting, MagicHitEffect, EnchantmentEffect)                                                                                   | "Type": [ "MagicCasting", "-EnchantmentEffect" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## ASTP - AssociationType
 
-| Field    | Alt | MFFSM | Value Type   | Example          |
-| -------- | --- | ----- | ------------ | ---------------- |
-| IsFamily |     | MFF-- | True / False | "IsFamily": true |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| IsFamily               |      | MFF-- | True / False                                                                                                                              | "IsFamily": true                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+
+[⬅ Back to Types](Types.md)
+
+## BPTD - BodyPartData
+
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## BOOK - Book
 
-| Field        | Alt            | MFFSM | Value Type                                               | Example                       |
-| ------------ | -------------- | ----- | -------------------------------------------------------- | ----------------------------- |
-| BookText     | DESC           | MFF-- | String value                                             | "BookText": "Hello"           |
-| Description  | CNAM;DESC      | MFF-- | String value                                             | "Description": "Hello"        |
-| Flags        | DataFlags;FNAM | MF--- | Flags (CantBeTaken)                                      | "Flags": "CantBeTaken"        |
-| InventoryArt | INAM           | MFF-- | Form Key or Editor ID                                    |                               |
-| Keywords     | KWDA           | MFFSM | Form Keys or Editor IDs                                  |                               |
-| Name         | FULL           | MFF-- | String value                                             | "Name": "Hello"               |
-| ObjectBounds | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9] |
-| PickUpSound  | YNAM           | MFF-- | Form Key or Editor ID                                    |                               |
-| PutDownSound | ZNAM           | MFF-- | Form Key or Editor ID                                    |                               |
-| Type         |                | MF--- | Possible values (BookOrTome, NoteOrScroll)               | "Type": "BookOrTome"          |
-| Value        |                | MFF-- | Numeric value                                            | "Value": 7                    |
-| Weight       |                | MFF-- | Decimal value                                            | "Weight": 3.14                |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| BookText               | DESC           | MFF-- | String value                                                                                                                              | "BookText": "Hello"                              |
+| Description            | CNAM;DESC      | MFF-- | String value                                                                                                                              | "Description": "Hello"                           |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (CantBeTaken)                                                                                                                       | "Flags": "CantBeTaken"                           |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| InventoryArt           | INAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Keywords               | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| PickUpSound            | YNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PutDownSound           | ZNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Type                   |                | MF--- | Possible values (BookOrTome, NoteOrScroll)                                                                                                | "Type": "BookOrTome"                             |
+| Value                  |                | MFF-- | Numeric value                                                                                                                             | "Value": 7                                       |
+| Weight                 |                | MFF-- | Decimal value                                                                                                                             | "Weight": 3.14                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## CPTH - CameraPath
 
-| Field                   | Alt | MFFSM | Value Type                         | Example                            |
-| ----------------------- | --- | ----- | ---------------------------------- | ---------------------------------- |
-| RelatedPaths            |     | MFFSM | Form Keys or Editor IDs            |                                    |
-| Shots                   |     | MFFSM | Form Keys or Editor IDs            |                                    |
-| Zoom                    |     | MF--- | Flags (Default, Disable, ShotList) | "Zoom": [ "Default", "-ShotList" ] |
-| ZoomMustHaveCameraShots |     | MFF-- | True / False                       | "ZoomMustHaveCameraShots": true    |
+| Field                   | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ----------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID                | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion             |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| RelatedPaths            | ANAM | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| Shots                   | SNAM | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| SkyrimMajorRecordFlags  |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Zoom                    |      | MF--- | Flags (Default, Disable, ShotList)                                                                                                        | "Zoom": [ "Default", "-ShotList" ]               |
+| ZoomMustHaveCameraShots |      | MFF-- | True / False                                                                                                                              | "ZoomMustHaveCameraShots": true                  |
 
 [⬅ Back to Types](Types.md)
 
 ## CAMS - CameraShot
 
-| Field                      | Alt            | MFFSM | Value Type                                                                                                            | Example                                                    |
-| -------------------------- | -------------- | ----- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| Action                     |                | MF--- | Possible values (Shoot, Fly, Hit, Zoom)                                                                               | "Action": "Shoot"                                          |
-| Flags                      | DataFlags;FNAM | MF--- | Flags (PositionFollowsLocation, RotationFollowsTarget, DoNotFollowBone, FirstPersonCamera, NoTracer, StartAtTimeZero) | "Flags": [ "PositionFollowsLocation", "-StartAtTimeZero" ] |
-| ImageSpaceModifier         | MNAM           | MFF-- | Form Key or Editor ID                                                                                                 |                                                            |
-| Location                   | XLCN           | MF--- | Possible values (Attacker, Projectile, Target, LeadActor)                                                             | "Location": "Attacker"                                     |
-| MaxTime                    |                | MFF-- | Decimal value                                                                                                         | "MaxTime": 3.14                                            |
-| MinTime                    |                | MFF-- | Decimal value                                                                                                         | "MinTime": 3.14                                            |
-| NearTargetDistance         |                | MFF-- | Decimal value                                                                                                         | "NearTargetDistance": 3.14                                 |
-| Target                     |                | MF--- | Possible values (Attacker, Projectile, Target, LeadActor)                                                             | "Target": "Attacker"                                       |
-| TargetPercentBetweenActors |                | MFF-- | Decimal value                                                                                                         | "TargetPercentBetweenActors": 3.14                         |
-| TimeMultiplierGlobal       |                | MFF-- | Decimal value                                                                                                         | "TimeMultiplierGlobal": 3.14                               |
-| TimeMultiplierPlayer       |                | MFF-- | Decimal value                                                                                                         | "TimeMultiplierPlayer": 3.14                               |
-| TimeMultiplierTarget       |                | MFF-- | Decimal value                                                                                                         | "TimeMultiplierTarget": 3.14                               |
+| Field                      | Alt            | MFFSM | Value Type                                                                                                                            | Example                                                    |
+| -------------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Action                     |                | MF--- | Possible values (Shoot, Fly, Hit, Zoom)                                                                                               | "Action": "Shoot"                                          |
+| EditorID                   | EDID           | MFF-- | String value                                                                                                                          | "EditorID": "Hello"                                        |
+| Flags                      | DataFlags;FNAM | MF--- | Flags (PositionFollowsLocation, RotationFollowsTarget, DoNotFollowBone, FirstPersonCamera, NoTracer, StartAtTimeZero)                 | "Flags": [ "PositionFollowsLocation", "-StartAtTimeZero" ] |
+| FormVersion                |                | MFF-- | Numeric value                                                                                                                         | "FormVersion": 7                                           |
+| ImageSpaceModifier         | MNAM           | MFF-- | Form Key or Editor ID                                                                                                                 |                                                            |
+| Location                   | XLCN           | MF--- | Possible values (Attacker, Projectile, Target, LeadActor)                                                                             | "Location": "Attacker"                                     |
+| MaxTime                    |                | MFF-- | Decimal value                                                                                                                         | "MaxTime": 3.14                                            |
+| MinTime                    |                | MFF-- | Decimal value                                                                                                                         | "MinTime": 3.14                                            |
+| NearTargetDistance         |                | MFF-- | Decimal value                                                                                                                         | "NearTargetDistance": 3.14                                 |
+| SkyrimMajorRecordFlags     |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]           |
+| Target                     |                | MF--- | Possible values (Attacker, Projectile, Target, LeadActor)                                                                             | "Target": "Attacker"                                       |
+| TargetPercentBetweenActors |                | MFF-- | Decimal value                                                                                                                         | "TargetPercentBetweenActors": 3.14                         |
+| TimeMultiplierGlobal       |                | MFF-- | Decimal value                                                                                                                         | "TimeMultiplierGlobal": 3.14                               |
+| TimeMultiplierPlayer       |                | MFF-- | Decimal value                                                                                                                         | "TimeMultiplierPlayer": 3.14                               |
+| TimeMultiplierTarget       |                | MFF-- | Decimal value                                                                                                                         | "TimeMultiplierTarget": 3.14                               |
 
 [⬅ Back to Types](Types.md)
 
 ## CELL - Cell
 
-| Field                   | Alt            | MFFSM | Value Type                                                                                                         | Example                                          |
-| ----------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
-| AcousticSpace           | XCAS           | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| EncounterZone           | XEZN           | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| FactionRank             |                | MFF-- | Numeric value                                                                                                      | "FactionRank": 7                                 |
-| Flags                   | DataFlags;FNAM | MF--- | Flags (IsInteriorCell, HasWater, CantTravelFromHere, NoLodWater, PublicArea, HandChanged, ShowSky, UseSkyLighting) | "Flags": [ "IsInteriorCell", "-UseSkyLighting" ] |
-| ImageSpace              | XCIM           | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| LightingTemplate        | LTMP           | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| Location                | XLCN           | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| LockList                | XILL           | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| MajorFlags              | RecordFlags    | MF--- | Flags (Persistent, OffLimits, CantWait)                                                                            | "MajorFlags": [ "Persistent", "-CantWait" ]      |
-| Music                   | XCMO           | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| Name                    | FULL           | MFF-- | String value                                                                                                       | "Name": "Hello"                                  |
-| Owner                   |                | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| Regions                 | XCLR           | MFFSM | Form Keys or Editor IDs                                                                                            |                                                  |
-| SkyAndWeatherFromRegion | XCCM           | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| Water                   | XCWT           | MFF-- | Form Key or Editor ID                                                                                              |                                                  |
-| WaterEnvironmentMap     | XWEM           | MFF-- | String value                                                                                                       | "WaterEnvironmentMap": "Hello"                   |
-| WaterHeight             | XCLW           | MFF-- | Decimal value                                                                                                      | "WaterHeight": 3.14                              |
-| WaterNoiseTexture       | XNAM           | MFF-- | String value                                                                                                       | "WaterNoiseTexture": "Hello"                     |
+| Field                   | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ----------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AcousticSpace           | XCAS           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| EditorID                | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| EncounterZone           | XEZN           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| FactionRank             | XRNK           | MFF-- | Numeric value                                                                                                                             | "FactionRank": 7                                 |
+| Flags                   | DataFlags;FNAM | MF--- | Flags (IsInteriorCell, HasWater, CantTravelFromHere, NoLodWater, PublicArea, HandChanged, ShowSky, UseSkyLighting)                        | "Flags": [ "IsInteriorCell", "-UseSkyLighting" ] |
+| FormVersion             |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| ImageSpace              | XCIM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| LightingTemplate        | LTMP           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| LNAM                    |                | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| Location                | XLCN           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| LockList                | XILL           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| MajorFlags              | RecordFlags    | MF--- | Flags (Persistent, OffLimits, CantWait)                                                                                                   | "MajorFlags": [ "Persistent", "-CantWait" ]      |
+| Music                   | XCMO           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Name                    | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| OcclusionData           | TVDT           | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| Owner                   | XOWN           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Regions                 | XCLR           | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| SkyAndWeatherFromRegion | XCCM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags  |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Water                   | XCWT           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| WaterEnvironmentMap     | XWEM           | MFF-- | String value                                                                                                                              | "WaterEnvironmentMap": "Hello"                   |
+| WaterHeight             | XCLW           | MFF-- | Decimal value                                                                                                                             | "WaterHeight": 3.14                              |
+| WaterNoiseTexture       | XNAM           | MFF-- | String value                                                                                                                              | "WaterNoiseTexture": "Hello"                     |
+| XWCN                    |                | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| XWCS                    |                | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
 
 [⬅ Back to Types](Types.md)
 
 ## CLAS - Class
 
-| Field            | Alt  | MFFSM | Value Type                                                                                                                                                                                   | Example                 |
-| ---------------- | ---- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| BleedoutDefault  |      | MFF-- | Decimal value                                                                                                                                                                                | "BleedoutDefault": 3.14 |
-| Description      | DESC | MFF-- | String value                                                                                                                                                                                 | "Description": "Hello"  |
-| Icon             |      | MFF-- | String value                                                                                                                                                                                 | "Icon": "Hello"         |
-| MaxTrainingLevel |      | MFF-- | Numeric value                                                                                                                                                                                | "MaxTrainingLevel": 7   |
-| Name             | FULL | MFF-- | String value                                                                                                                                                                                 | "Name": "Hello"         |
-| Teaches          |      | MF--- | Possible values (OneHanded, TwoHanded, Archery, Block, Smithing, HeavyArmor, LightArmor, Pickpocket, Lockpicking, Sneak, Alchemy, Speech, Alteration, Conjuration, Destruction, Illusion, Restoration, Enchanting) | "Teaches": "OneHanded"  |
-| VoicePoints      |      | MFF-- | Numeric value                                                                                                                                                                                | "VoicePoints": 7        |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                                    | Example                                          |
+| ---------------------- | ---- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| BleedoutDefault        |      | MFF-- | Decimal value                                                                                                                                                 | "BleedoutDefault": 3.14                          |
+| Description            | DESC | MFF-- | String value                                                                                                                                                  | "Description": "Hello"                           |
+| EditorID               | EDID | MFF-- | String value                                                                                                                                                  | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                                                 | "FormVersion": 7                                 |
+| Icon                   |      | MFF-- | String value                                                                                                                                                  | "Icon": "Hello"                                  |
+| MaxTrainingLevel       |      | MFF-- | Numeric value                                                                                                                                                 | "MaxTrainingLevel": 7                            |
+| Name                   | FULL | MFF-- | String value                                                                                                                                                  | "Name": "Hello"                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)                     | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Teaches                |      | MF--- | Possible values (OneHanded, TwoHanded, Archery, Block, Smithing, HeavyArmor, LightArmor, Pickpocket, Lockpicking, Sneak, Alchemy, Speech, Alteration, Conjuration, Destruction, Illusion, Restoration, Enchanting) | "Teaches": "OneHanded"                           |
+| VoicePoints            |      | MFF-- | Numeric value                                                                                                                                                 | "VoicePoints": 7                                 |
 
 [⬅ Back to Types](Types.md)
 
 ## CLMT - Climate
 
-| Field       | Alt | MFFSM | Value Type              | Example                           |
-| ----------- | --- | ----- | ----------------------- | --------------------------------- |
-| Moons       |     | MF--- | Flags (Masser, Secunda) | "Moons": [ "Masser", "-Secunda" ] |
-| PhaseLength |     | MFF-- | Numeric value           | "PhaseLength": 7                  |
-| Volatility  |     | MFF-- | Numeric value           | "Volatility": 7                   |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Moons                  |      | MF--- | Flags (Masser, Secunda)                                                                                                                   | "Moons": [ "Masser", "-Secunda" ]                |
+| PhaseLength            |      | MFF-- | Numeric value                                                                                                                             | "PhaseLength": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Volatility             |      | MFF-- | Numeric value                                                                                                                             | "Volatility": 7                                  |
 
 [⬅ Back to Types](Types.md)
 
 ## COLL - CollisionLayer
 
-| Field        | Alt                 | MFFSM | Value Type                                                                                                                                               | Example                                          |
-| ------------ | ------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| CollidesWith | CNAM                | MFFSM | Form Keys or Editor IDs                                                                                                                                  |                                                  |
-| DebugColor   | FNAM                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "DebugColor": [40,50,60]                         |
-| Description  | DESC                | MFF-- | String value                                                                                                                                             | "Description": "Hello"                           |
-| Flags        | DataFlags;FNAM;GNAM | MF--- | Flags (TriggerVolume, Sensor, NavmeshObstacle)                                                                                                           | "Flags": [ "TriggerVolume", "-NavmeshObstacle" ] |
-| Index        | BNAM                | MFF-- | Numeric value                                                                                                                                            | "Index": 7                                       |
-| Name         | FULL;MNAM           | MFF-- | String value                                                                                                                                             | "Name": "Hello"                                  |
+| Field                  | Alt                 | MFFSM | Value Type                                                                                                                                     | Example                                          |
+| ---------------------- | ------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| CollidesWith           | CNAM                | MFFSM | Form Keys or Editor IDs                                                                                                                        |                                                  |
+| DebugColor             | FNAM                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "DebugColor": [40,50,60]                         |
+| Description            | DESC                | MFF-- | String value                                                                                                                                   | "Description": "Hello"                           |
+| EditorID               | EDID                | MFF-- | String value                                                                                                                                   | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM;GNAM | MF--- | Flags (TriggerVolume, Sensor, NavmeshObstacle)                                                                                                 | "Flags": [ "TriggerVolume", "-NavmeshObstacle" ] |
+| FormVersion            |                     | MFF-- | Numeric value                                                                                                                                  | "FormVersion": 7                                 |
+| Index                  | BNAM                | MFF-- | Numeric value                                                                                                                                  | "Index": 7                                       |
+| Name                   | FULL;MNAM           | MFF-- | String value                                                                                                                                   | "Name": "Hello"                                  |
+| SkyrimMajorRecordFlags |                     | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)      | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## CLFM - ColorRecord
 
-| Field    | Alt  | MFFSM | Value Type                                                                                                                                                                                               | Example             |
-| -------- | ---- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| Color    |      | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60] |
-| Name     | FULL | MFF-- | String value                                                                                                                                                                                             | "Name": "Hello"     |
-| Playable | FNAM | MFF-- | True / False                                                                                                                                                                                             | "Playable": true    |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                                    | Example                                          |
+| ---------------------- | ---- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Color                  | CNAM | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60]                              |
+| EditorID               | EDID | MFF-- | String value                                                                                                                                                  | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                                                 | "FormVersion": 7                                 |
+| Name                   | FULL | MFF-- | String value                                                                                                                                                  | "Name": "Hello"                                  |
+| Playable               | FNAM | MFF-- | True / False                                                                                                                                                  | "Playable": true                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)                     | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## CSTY - CombatStyle
 
-| Field                     | Alt            | MFFSM | Value Type                                   | Example                                      |
-| ------------------------- | -------------- | ----- | -------------------------------------------- | -------------------------------------------- |
-| AvoidThreatChance         |                | MFF-- | Decimal value                                | "AvoidThreatChance": 3.14                    |
-| CSGDDataTypeState         |                | MF--- | Flags (Break0, Break1)                       | "CSGDDataTypeState": [ "Break0", "-Break1" ] |
-| DefensiveMult             |                | MFF-- | Decimal value                                | "DefensiveMult": 3.14                        |
-| EquipmentScoreMultMagic   |                | MFF-- | Decimal value                                | "EquipmentScoreMultMagic": 3.14              |
-| EquipmentScoreMultMelee   |                | MFF-- | Decimal value                                | "EquipmentScoreMultMelee": 3.14              |
-| EquipmentScoreMultRanged  |                | MFF-- | Decimal value                                | "EquipmentScoreMultRanged": 3.14             |
-| EquipmentScoreMultShout   |                | MFF-- | Decimal value                                | "EquipmentScoreMultShout": 3.14              |
-| EquipmentScoreMultStaff   |                | MFF-- | Decimal value                                | "EquipmentScoreMultStaff": 3.14              |
-| EquipmentScoreMultUnarmed |                | MFF-- | Decimal value                                | "EquipmentScoreMultUnarmed": 3.14            |
-| Flags                     | DataFlags;FNAM | MF--- | Flags (Dueling, Flanking, AllowDualWielding) | "Flags": [ "Dueling", "-AllowDualWielding" ] |
-| GroupOffensiveMult        |                | MFF-- | Decimal value                                | "GroupOffensiveMult": 3.14                   |
-| LongRangeStrafeMult       | CSLR           | MFF-- | Decimal value                                | "LongRangeStrafeMult": 3.14                  |
-| MajorFlags                | RecordFlags    | MF--- | Flags (AllowDualWielding)                    | "MajorFlags": "AllowDualWielding"            |
-| OffensiveMult             |                | MFF-- | Decimal value                                | "OffensiveMult": 3.14                        |
+| Field                     | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ------------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AvoidThreatChance         |                | MFF-- | Decimal value                                                                                                                             | "AvoidThreatChance": 3.14                        |
+| CSGDDataTypeState         |                | MF--- | Flags (Break0, Break1)                                                                                                                    | "CSGDDataTypeState": [ "Break0", "-Break1" ]     |
+| CSMD                      |                | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| DefensiveMult             |                | MFF-- | Decimal value                                                                                                                             | "DefensiveMult": 3.14                            |
+| EditorID                  | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| EquipmentScoreMultMagic   |                | MFF-- | Decimal value                                                                                                                             | "EquipmentScoreMultMagic": 3.14                  |
+| EquipmentScoreMultMelee   |                | MFF-- | Decimal value                                                                                                                             | "EquipmentScoreMultMelee": 3.14                  |
+| EquipmentScoreMultRanged  |                | MFF-- | Decimal value                                                                                                                             | "EquipmentScoreMultRanged": 3.14                 |
+| EquipmentScoreMultShout   |                | MFF-- | Decimal value                                                                                                                             | "EquipmentScoreMultShout": 3.14                  |
+| EquipmentScoreMultStaff   |                | MFF-- | Decimal value                                                                                                                             | "EquipmentScoreMultStaff": 3.14                  |
+| EquipmentScoreMultUnarmed |                | MFF-- | Decimal value                                                                                                                             | "EquipmentScoreMultUnarmed": 3.14                |
+| Flags                     | DataFlags;FNAM | MF--- | Flags (Dueling, Flanking, AllowDualWielding)                                                                                              | "Flags": [ "Dueling", "-AllowDualWielding" ]     |
+| FormVersion               |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| GroupOffensiveMult        |                | MFF-- | Decimal value                                                                                                                             | "GroupOffensiveMult": 3.14                       |
+| LongRangeStrafeMult       | CSLR           | MFF-- | Decimal value                                                                                                                             | "LongRangeStrafeMult": 3.14                      |
+| MajorFlags                | RecordFlags    | MF--- | Flags (AllowDualWielding)                                                                                                                 | "MajorFlags": "AllowDualWielding"                |
+| OffensiveMult             |                | MFF-- | Decimal value                                                                                                                             | "OffensiveMult": 3.14                            |
+| SkyrimMajorRecordFlags    |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## COBJ - ConstructibleObject
 
-| Field              | Alt  | MFFSM | Value Type                                                      | Example                                              |
-| ------------------ | ---- | ----- | --------------------------------------------------------------- | ---------------------------------------------------- |
-| CreatedObject      | CNAM | MFF-- | Form Key or Editor ID                                           |                                                      |
-| CreatedObjectCount | NAM1 | MFF-- | Numeric value                                                   | "CreatedObjectCount": 7                              |
-| Items              | Item | MFFSM | JSON objects containing item Form Key/Editor ID and Count (QTY) | "Items": { "Item": "021FED:Skyrim.esm", "Count": 3 } |
-| WorkbenchKeyword   | BNAM | MFF-- | Form Key or Editor ID                                           |                                                      |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                              |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| CreatedObject          | CNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                      |
+| CreatedObjectCount     | NAM1 | MFF-- | Numeric value                                                                                                                             | "CreatedObjectCount": 7                              |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                  |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                     |
+| Items                  | Item | MFFSM | JSON objects containing item Form Key/Editor ID and Count (QTY)                                                                           | "Items": { "Item": "021FED:Skyrim.esm", "Count": 3 } |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]     |
+| WorkbenchKeyword       | BNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                      |
 
 [⬅ Back to Types](Types.md)
 
 ## CONT - Container
 
-| Field        | Alt            | MFFSM | Value Type                                                                                                                       | Example                                                       |
-| ------------ | -------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| CloseSound   | QNAM           | MFF-- | Form Key or Editor ID                                                                                                            |                                                               |
-| Flags        | DataFlags;FNAM | MF--- | Flags (AllowSoundsWhenAnimation, Respawns, ShowOwner)                                                                            | "Flags": [ "AllowSoundsWhenAnimation", "-ShowOwner" ]         |
-| Items        | Item           | MFFSM | JSON objects containing item Form Key/Editor ID and Count (QTY)                                                                  | "Items": { "Item": "021FED:Skyrim.esm", "Count": 3 }          |
-| MajorFlags   | RecordFlags    | MF--- | Flags (HasDistantLOD, RandomAnimStart, Obstacle, NavMeshGenerationFilter, NavMeshGenerationBoundingBox, NavMeshGenerationGround) | "MajorFlags": [ "HasDistantLOD", "-NavMeshGenerationGround" ] |
-| Name         | FULL           | MFF-- | String value                                                                                                                     | "Name": "Hello"                                               |
-| ObjectBounds | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                         | "ObjectBounds": [6,6,6,9,9,9]                                 |
-| OpenSound    | SNAM           | MFF-- | Form Key or Editor ID                                                                                                            |                                                               |
-| Weight       |                | MFF-- | Decimal value                                                                                                                    | "Weight": 3.14                                                |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                             | Example                                                       |
+| ---------------------- | -------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| CloseSound             | QNAM           | MFF-- | Form Key or Editor ID                                                                                                                  |                                                               |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                           | "EditorID": "Hello"                                           |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (AllowSoundsWhenAnimation, Respawns, ShowOwner)                                                                                  | "Flags": [ "AllowSoundsWhenAnimation", "-ShowOwner" ]         |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                          | "FormVersion": 7                                              |
+| Items                  | Item           | MFFSM | JSON objects containing item Form Key/Editor ID and Count (QTY)                                                                        | "Items": { "Item": "021FED:Skyrim.esm", "Count": 3 }          |
+| MajorFlags             | RecordFlags    | MF--- | Flags (HasDistantLOD, RandomAnimStart, Obstacle, NavMeshGenerationFilter, NavMeshGenerationBoundingBox, NavMeshGenerationGround)       | "MajorFlags": [ "HasDistantLOD", "-NavMeshGenerationGround" ] |
+| Name                   | FULL           | MFF-- | String value                                                                                                                           | "Name": "Hello"                                               |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                               | "ObjectBounds": [6,6,6,9,9,9]                                 |
+| OpenSound              | SNAM           | MFF-- | Form Key or Editor ID                                                                                                                  |                                                               |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]              |
+| Weight                 |                | MFF-- | Decimal value                                                                                                                          | "Weight": 3.14                                                |
+
+[⬅ Back to Types](Types.md)
+
+## DEBR - Debris
+
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+
+[⬅ Back to Types](Types.md)
+
+## DOBJ - DefaultObjectManager
+
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## DLBR - DialogBranch
 
-| Field         | Alt            | MFFSM | Value Type                            | Example                               |
-| ------------- | -------------- | ----- | ------------------------------------- | ------------------------------------- |
-| Category      | TNAM           | MF--- | Possible values (Player, Command)     | "Category": "Player"                  |
-| Flags         | DataFlags;FNAM | MF--- | Flags (TopLevel, Blocking, Exclusive) | "Flags": [ "TopLevel", "-Exclusive" ] |
-| Quest         | QNAM           | MFF-- | Form Key or Editor ID                 |                                       |
-| StartingTopic | SNAM           | MFF-- | Form Key or Editor ID                 |                                       |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Category               | TNAM           | MF--- | Possible values (Player, Command)                                                                                                         | "Category": "Player"                             |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (TopLevel, Blocking, Exclusive)                                                                                                     | "Flags": [ "TopLevel", "-Exclusive" ]            |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Quest                  | QNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| StartingTopic          | SNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
 
 [⬅ Back to Types](Types.md)
 
 ## DIAL - DialogTopic
 
-| Field      | Alt  | MFFSM | Value Type                                                                                                                                                                            | Example                              |
-| ---------- | ---- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| Branch     | BNAM | MFF-- | Form Key or Editor ID                                                                                                                                                                 |                                      |
-| Category   |      | MF--- | Possible values (Topic, Favor, Scene, Combat, Favors, Detection, Service, Misc)                                                                                                       | "Category": "Topic"                  |
-| Name       | FULL | MFF-- | String value                                                                                                                                                                          | "Name": "Hello"                      |
-| Priority   | PNAM | MFF-- | Decimal value                                                                                                                                                                         | "Priority": 3.14                     |
-| Quest      | QNAM | MFF-- | Form Key or Editor ID                                                                                                                                                                 |                                      |
-| Subtype    | SNAM | MF--- | Possible values (Custom, ForceGreet, Rumors, Intimidate, Flatter, Bribe, AskGift, Gift, AskFavor, Favor, ShowRelationships, Follow, Reject, Scene, Show, Agree, Refuse, ExitFavorState, MoralRefusal, FlyingMountLand, FlyingMountCancelLand, FlyingMountAcceptTarget, FlyingMountRejectTarget, FlyingMountNoTarget, FlyingMountDestinationReached, Attack, PowerAttack, Bash, Hit, Flee, Bleedout, AvoidThreat, Death, GroupStrategy, Block, Taunt, AllyKilled, Steal, Yield, AcceptYield, PickpocketCombat, Assault, Murder, AssaultNC, MurderNC, PickpocketNC, StealFromNC, TrespassAgainstNC, Trespass, WerewolfTransformCrime, VoicePowerStartShort, VoicePowerStartLong, VoicePowerEndShort, VoicePowerEndLong, AlertIdle, LostIdle, NormalToAlert, AlertToCombat, NormalToCombat, AlertToNormal, CombatToNormal, CombatToLost, LostToNormal, LostToCombat, DetectFriendDie, ServiceRefusal, Repair, Travel, Training, BarterExit, RepairExit, Recharge, RechargeExit, TrainingExit, ObserveCombat, NoticeCorpse, TimeToGo, Goodbye, Hello, SwingMeleeWeapon, ShootBow, ZKeyObject, Jump, KnockOverObject, DestroyObject, StandOnFurniture, LockedObject, PickpocketTopic, PursueIdleTopic, SharedInfo, PlayerCastProjectileSpell, PlayerCastSelfSpell, PlayerShout, Idle, EnterSprintBreath, EnterBowZoomBreath, ExitBowZoomBreath, ActorCollideWithActor, PlayerInIronSights, OutOfBreath, CombatGrunt, LeaveWaterBreath) | "Subtype": "Custom"                  |
-| TopicFlags |      | MF--- | Flags (DoAllBeforeRepeating)                                                                                                                                                          | "TopicFlags": "DoAllBeforeRepeating" |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                                    | Example                                          |
+| ---------------------- | ---- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Branch                 | BNAM | MFF-- | Form Key or Editor ID                                                                                                                                         |                                                  |
+| Category               |      | MF--- | Possible values (Topic, Favor, Scene, Combat, Favors, Detection, Service, Misc)                                                                               | "Category": "Topic"                              |
+| EditorID               | EDID | MFF-- | String value                                                                                                                                                  | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                                                 | "FormVersion": 7                                 |
+| Name                   | FULL | MFF-- | String value                                                                                                                                                  | "Name": "Hello"                                  |
+| Priority               | PNAM | MFF-- | Decimal value                                                                                                                                                 | "Priority": 3.14                                 |
+| Quest                  | QNAM | MFF-- | Form Key or Editor ID                                                                                                                                         |                                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)                     | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Subtype                | SNAM | MF--- | Possible values (Custom, ForceGreet, Rumors, Intimidate, Flatter, Bribe, AskGift, Gift, AskFavor, Favor, ShowRelationships, Follow, Reject, Scene, Show, Agree, Refuse, ExitFavorState, MoralRefusal, FlyingMountLand, FlyingMountCancelLand, FlyingMountAcceptTarget, FlyingMountRejectTarget, FlyingMountNoTarget, FlyingMountDestinationReached, Attack, PowerAttack, Bash, Hit, Flee, Bleedout, AvoidThreat, Death, GroupStrategy, Block, Taunt, AllyKilled, Steal, Yield, AcceptYield, PickpocketCombat, Assault, Murder, AssaultNC, MurderNC, PickpocketNC, StealFromNC, TrespassAgainstNC, Trespass, WerewolfTransformCrime, VoicePowerStartShort, VoicePowerStartLong, VoicePowerEndShort, VoicePowerEndLong, AlertIdle, LostIdle, NormalToAlert, AlertToCombat, NormalToCombat, AlertToNormal, CombatToNormal, CombatToLost, LostToNormal, LostToCombat, DetectFriendDie, ServiceRefusal, Repair, Travel, Training, BarterExit, RepairExit, Recharge, RechargeExit, TrainingExit, ObserveCombat, NoticeCorpse, TimeToGo, Goodbye, Hello, SwingMeleeWeapon, ShootBow, ZKeyObject, Jump, KnockOverObject, DestroyObject, StandOnFurniture, LockedObject, PickpocketTopic, PursueIdleTopic, SharedInfo, PlayerCastProjectileSpell, PlayerCastSelfSpell, PlayerShout, Idle, EnterSprintBreath, EnterBowZoomBreath, ExitBowZoomBreath, ActorCollideWithActor, PlayerInIronSights, OutOfBreath, CombatGrunt, LeaveWaterBreath) | "Subtype": "Custom"                              |
+| TopicFlags             |      | MF--- | Flags (DoAllBeforeRepeating)                                                                                                                                  | "TopicFlags": "DoAllBeforeRepeating"             |
 
 [⬅ Back to Types](Types.md)
 
 ## DLVW - DialogView
 
-| Field    | Alt  | MFFSM | Value Type              | Example |
-| -------- | ---- | ----- | ----------------------- | ------- |
-| Branches | BNAM | MFFSM | Form Keys or Editor IDs |         |
-| Quest    | QNAM | MFF-- | Form Key or Editor ID   |         |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Branches               | BNAM | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| DNAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| ENAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Quest                  | QNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## DOOR - Door
 
-| Field        | Alt            | MFFSM | Value Type                                                              | Example                                              |
-| ------------ | -------------- | ----- | ----------------------------------------------------------------------- | ---------------------------------------------------- |
-| CloseSound   | ANAM           | MFF-- | Form Key or Editor ID                                                   |                                                      |
-| Flags        | DataFlags;FNAM | MF--- | Flags (Automatic, Hidden, MinimalUse, Sliding, DoNotOpenInCombatSearch) | "Flags": [ "Automatic", "-DoNotOpenInCombatSearch" ] |
-| LoopSound    | BNAM           | MFF-- | Form Key or Editor ID                                                   |                                                      |
-| MajorFlags   | RecordFlags    | MF--- | Flags (HasDistantLOD, RandomAnimStart, IsMarker)                        | "MajorFlags": [ "HasDistantLOD", "-IsMarker" ]       |
-| Name         | FULL           | MFF-- | String value                                                            | "Name": "Hello"                                      |
-| ObjectBounds | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                | "ObjectBounds": [6,6,6,9,9,9]                        |
-| OpenSound    | SNAM           | MFF-- | Form Key or Editor ID                                                   |                                                      |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                              |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| CloseSound             | ANAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                      |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                  |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (Automatic, Hidden, MinimalUse, Sliding, DoNotOpenInCombatSearch)                                                                   | "Flags": [ "Automatic", "-DoNotOpenInCombatSearch" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                     |
+| LoopSound              | BNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                      |
+| MajorFlags             | RecordFlags    | MF--- | Flags (HasDistantLOD, RandomAnimStart, IsMarker)                                                                                          | "MajorFlags": [ "HasDistantLOD", "-IsMarker" ]       |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                      |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                        |
+| OpenSound              | SNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                      |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]     |
 
 [⬅ Back to Types](Types.md)
 
 ## DUAL - DualCastData
 
-| Field         | Alt  | MFFSM | Value Type                                               | Example                                          |
-| ------------- | ---- | ----- | -------------------------------------------------------- | ------------------------------------------------ |
-| EffectShader  |      | MFF-- | Form Key or Editor ID                                    |                                                  |
-| Explosion     |      | MFF-- | Form Key or Editor ID                                    |                                                  |
-| HitEffectArt  |      | MFF-- | Form Key or Editor ID                                    |                                                  |
-| ImpactDataSet |      | MFF-- | Form Key or Editor ID                                    |                                                  |
-| InheritScale  |      | MF--- | Flags (HitEffectArt, Projectile, Explosion)              | "InheritScale": [ "HitEffectArt", "-Explosion" ] |
-| ObjectBounds  | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9]                    |
-| Projectile    |      | MFF-- | Form Key or Editor ID                                    |                                                  |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| EffectShader           |      | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Explosion              |      | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| HitEffectArt           |      | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| ImpactDataSet          |      | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| InheritScale           |      | MF--- | Flags (HitEffectArt, Projectile, Explosion)                                                                                               | "InheritScale": [ "HitEffectArt", "-Explosion" ] |
+| ObjectBounds           | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| Projectile             |      | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
@@ -437,6 +559,7 @@ This just details where the field can currently be used.
 | EdgeEffectFullAlphaTime                    |                | MFF-- | Decimal value                                                                                                               | "EdgeEffectFullAlphaTime": 3.14                      |
 | EdgeEffectPersistentAlphaRatio             |                | MFF-- | Decimal value                                                                                                               | "EdgeEffectPersistentAlphaRatio": 3.14               |
 | EdgeWidth                                  |                | MFF-- | Decimal value                                                                                                               | "EdgeWidth": 3.14                                    |
+| EditorID                                   | EDID           | MFF-- | String value                                                                                                                | "EditorID": "Hello"                                  |
 | ExplosionWindSpeed                         |                | MFF-- | Decimal value                                                                                                               | "ExplosionWindSpeed": 3.14                           |
 | FillAlphaFadeInTime                        |                | MFF-- | Decimal value                                                                                                               | "FillAlphaFadeInTime": 3.14                          |
 | FillAlphaPulseAmplitude                    |                | MFF-- | Decimal value                                                                                                               | "FillAlphaPulseAmplitude": 3.14                      |
@@ -459,6 +582,7 @@ This just details where the field can currently be used.
 | FillTextureScaleU                          |                | MFF-- | Decimal value                                                                                                               | "FillTextureScaleU": 3.14                            |
 | FillTextureScaleV                          |                | MFF-- | Decimal value                                                                                                               | "FillTextureScaleV": 3.14                            |
 | Flags                                      | DataFlags;FNAM | MF--- | Flags (NoMembraneShader, MembraneGrayscaleColor, MembraneGrayscaleAlpha, NoParticleShader, EdgeEffectInverse, AffectSkinOnly, TextureEffectIgnoreAlpha, TextureEffectProjectUVs, IgnoreBaseGeometryAlpha, TextureEffectLighting, TextureEffectNoWeapons, ParticleAnimated, ParticleGrayscaleColor, ParticleGrayscaleAlpha, UseBloodGeometry) | "Flags": [ "NoMembraneShader", "-UseBloodGeometry" ] |
+| FormVersion                                |                | MFF-- | Numeric value                                                                                                               | "FormVersion": 7                                     |
 | HolesEndTime                               |                | MFF-- | Decimal value                                                                                                               | "HolesEndTime": 3.14                                 |
 | HolesEndValue                              |                | MFF-- | Decimal value                                                                                                               | "HolesEndValue": 3.14                                |
 | HolesStartTime                             |                | MFF-- | Decimal value                                                                                                               | "HolesStartTime": 3.14                               |
@@ -503,6 +627,7 @@ This just details where the field can currently be used.
 | ParticleSourceBlendMode                    |                | MF--- | Possible values (Zero, One, SourceColor, SourceInverseColor, SourceAlpha, SourceInvertedAlpha, DestAlpha, DestInvertedAlpha, DestColor, DestInverseColor, SourceAlphaSat) | "ParticleSourceBlendMode": "Zero"                    |
 | ParticleZTest                              |                | MF--- | Possible values (EqualTo, Normal, GreaterThan, GreaterThanOrEqualTo, AlwaysShow)                                            | "ParticleZTest": "EqualTo"                           |
 | SceneGraphEmitDepthLimit                   |                | MFF-- | Numeric value                                                                                                               | "SceneGraphEmitDepthLimit": 7                        |
+| SkyrimMajorRecordFlags                     |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]     |
 | TextureCountU                              |                | MFF-- | Numeric value                                                                                                               | "TextureCountU": 7                                   |
 | TextureCountV                              |                | MFF-- | Numeric value                                                                                                               | "TextureCountV": 7                                   |
 
@@ -510,57 +635,69 @@ This just details where the field can currently be used.
 
 ## ECZN - EncounterZone
 
-| Field    | Alt            | MFFSM | Value Type                                                           | Example                                              |
-| -------- | -------------- | ----- | -------------------------------------------------------------------- | ---------------------------------------------------- |
-| Flags    | DataFlags;FNAM | MF--- | Flags (NeverResets, MatchPcBelowMinimumLevel, DisableCombatBoundary) | "Flags": [ "NeverResets", "-DisableCombatBoundary" ] |
-| Location | XLCN           | MFF-- | Form Key or Editor ID                                                |                                                      |
-| MaxLevel |                | MFF-- | Numeric value                                                        | "MaxLevel": 7                                        |
-| MinLevel |                | MFF-- | Numeric value                                                        | "MinLevel": 7                                        |
-| Owner    |                | MFF-- | Form Key or Editor ID                                                |                                                      |
-| Rank     |                | MFF-- | Numeric value                                                        | "Rank": 7                                            |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                              |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                  |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (NeverResets, MatchPcBelowMinimumLevel, DisableCombatBoundary)                                                                      | "Flags": [ "NeverResets", "-DisableCombatBoundary" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                     |
+| Location               | XLCN           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                      |
+| MaxLevel               |                | MFF-- | Numeric value                                                                                                                             | "MaxLevel": 7                                        |
+| MinLevel               |                | MFF-- | Numeric value                                                                                                                             | "MinLevel": 7                                        |
+| Owner                  |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                      |
+| Rank                   |                | MFF-- | Numeric value                                                                                                                             | "Rank": 7                                            |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]     |
 
 [⬅ Back to Types](Types.md)
 
 ## EQUP - EquipType
 
-| Field         | Alt  | MFFSM | Value Type              | Example               |
-| ------------- | ---- | ----- | ----------------------- | --------------------- |
-| SlotParents   | PNAM | MFFSM | Form Keys or Editor IDs |                       |
-| UseAllParents | DATA | MFF-- | True / False            | "UseAllParents": true |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| SlotParents            | PNAM | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| UseAllParents          | DATA | MFF-- | True / False                                                                                                                              | "UseAllParents": true                            |
 
 [⬅ Back to Types](Types.md)
 
 ## EXPL - Explosion
 
-| Field              | Alt            | MFFSM | Value Type                                                                                                                           | Example                                                             |
-| ------------------ | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
-| Damage             |                | MFF-- | Decimal value                                                                                                                        | "Damage": 3.14                                                      |
-| Flags              | DataFlags;FNAM | MF--- | Flags (AlwaysUsesWorldOrientation, KnockDownAlways, KnockDownByFormula, IgnoreLosCheck, PushExplosionSourceRefOnly, IgnoreImageSpaceSwap, Chain, NoControllerVibration) | "Flags": [ "AlwaysUsesWorldOrientation", "-NoControllerVibration" ] |
-| Force              |                | MFF-- | Decimal value                                                                                                                        | "Force": 3.14                                                       |
-| ImageSpaceModifier | MNAM           | MFF-- | Form Key or Editor ID                                                                                                                |                                                                     |
-| ImpactDataSet      |                | MFF-- | Form Key or Editor ID                                                                                                                |                                                                     |
-| ISRadius           |                | MFF-- | Decimal value                                                                                                                        | "ISRadius": 3.14                                                    |
-| Light              |                | MFF-- | Form Key or Editor ID                                                                                                                |                                                                     |
-| Name               | FULL           | MFF-- | String value                                                                                                                         | "Name": "Hello"                                                     |
-| ObjectBounds       | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                             | "ObjectBounds": [6,6,6,9,9,9]                                       |
-| ObjectEffect       | EITM           | MFF-- | Form Key or Editor ID                                                                                                                |                                                                     |
-| PlacedObject       |                | MFF-- | Form Key or Editor ID                                                                                                                |                                                                     |
-| Radius             |                | MFF-- | Decimal value                                                                                                                        | "Radius": 3.14                                                      |
-| Sound1             |                | MFF-- | Form Key or Editor ID                                                                                                                |                                                                     |
-| Sound2             |                | MFF-- | Form Key or Editor ID                                                                                                                |                                                                     |
-| SoundLevel         |                | MF--- | Possible values (Loud, Normal, Silent, VeryLoud)                                                                                     | "SoundLevel": "Loud"                                                |
-| SpawnProjectile    |                | MFF-- | Form Key or Editor ID                                                                                                                |                                                                     |
-| VerticalOffsetMult |                | MFF-- | Decimal value                                                                                                                        | "VerticalOffsetMult": 3.14                                          |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                       | Example                                                             |
+| ---------------------- | -------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Damage                 |                | MFF-- | Decimal value                                                                                                                    | "Damage": 3.14                                                      |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                     | "EditorID": "Hello"                                                 |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (AlwaysUsesWorldOrientation, KnockDownAlways, KnockDownByFormula, IgnoreLosCheck, PushExplosionSourceRefOnly, IgnoreImageSpaceSwap, Chain, NoControllerVibration) | "Flags": [ "AlwaysUsesWorldOrientation", "-NoControllerVibration" ] |
+| Force                  |                | MFF-- | Decimal value                                                                                                                    | "Force": 3.14                                                       |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                    | "FormVersion": 7                                                    |
+| ImageSpaceModifier     | MNAM           | MFF-- | Form Key or Editor ID                                                                                                            |                                                                     |
+| ImpactDataSet          |                | MFF-- | Form Key or Editor ID                                                                                                            |                                                                     |
+| ISRadius               |                | MFF-- | Decimal value                                                                                                                    | "ISRadius": 3.14                                                    |
+| Light                  |                | MFF-- | Form Key or Editor ID                                                                                                            |                                                                     |
+| Name                   | FULL           | MFF-- | String value                                                                                                                     | "Name": "Hello"                                                     |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                         | "ObjectBounds": [6,6,6,9,9,9]                                       |
+| ObjectEffect           | EITM           | MFF-- | Form Key or Editor ID                                                                                                            |                                                                     |
+| PlacedObject           |                | MFF-- | Form Key or Editor ID                                                                                                            |                                                                     |
+| Radius                 |                | MFF-- | Decimal value                                                                                                                    | "Radius": 3.14                                                      |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                    |
+| Sound1                 |                | MFF-- | Form Key or Editor ID                                                                                                            |                                                                     |
+| Sound2                 |                | MFF-- | Form Key or Editor ID                                                                                                            |                                                                     |
+| SoundLevel             |                | MF--- | Possible values (Loud, Normal, Silent, VeryLoud)                                                                                 | "SoundLevel": "Loud"                                                |
+| SpawnProjectile        |                | MFF-- | Form Key or Editor ID                                                                                                            |                                                                     |
+| VerticalOffsetMult     |                | MFF-- | Decimal value                                                                                                                    | "VerticalOffsetMult": 3.14                                          |
 
 [⬅ Back to Types](Types.md)
 
 ## EYES - Eyes
 
-| Field      | Alt            | MFFSM | Value Type                           | Example                               |
-| ---------- | -------------- | ----- | ------------------------------------ | ------------------------------------- |
-| Flags      | DataFlags;FNAM | MF--- | Flags (Playable, NotMale, NotFemale) | "Flags": [ "Playable", "-NotFemale" ] |
-| MajorFlags | RecordFlags    | MF--- | Flags (NonPlayable)                  | "MajorFlags": "NonPlayable"           |
-| Name       | FULL           | MFF-- | String value                         | "Name": "Hello"                       |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (Playable, NotMale, NotFemale)                                                                                                      | "Flags": [ "Playable", "-NotFemale" ]            |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| MajorFlags             | RecordFlags    | MF--- | Flags (NonPlayable)                                                                                                                       | "MajorFlags": "NonPlayable"                      |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
@@ -568,15 +705,18 @@ This just details where the field can currently be used.
 
 | Field                    | Alt            | MFFSM | Value Type                                                                                                                    | Example                                                              |
 | ------------------------ | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| EditorID                 | EDID           | MFF-- | String value                                                                                                                  | "EditorID": "Hello"                                                  |
 | ExteriorJailMarker       | JAIL           | MFF-- | Form Key or Editor ID                                                                                                         |                                                                      |
 | Flags                    | DataFlags;FNAM | MF--- | Flags (HiddenFromPC, SpecialCombat, TrackCrime, IgnoreMurder, IgnoreAssault, IgnoreStealing, IgnoreTrespass, DoNotReportCrimesAgainstMembers, CrimeGoldUseDefaults, IgnorePickpocket, Vendor, CanBeOwner, IgnoreWerewolf) | "Flags": [ "HiddenFromPC", "-IgnoreWerewolf" ]                       |
 | FollowerWaitMarker       | WAIT           | MFF-- | Form Key or Editor ID                                                                                                         |                                                                      |
+| FormVersion              |                | MFF-- | Numeric value                                                                                                                 | "FormVersion": 7                                                     |
 | JailOutfit               | JOUT           | MFF-- | Form Key or Editor ID                                                                                                         |                                                                      |
 | MerchantContainer        | VENC           | MFF-- | Form Key or Editor ID                                                                                                         |                                                                      |
 | Name                     | FULL           | MFF-- | String value                                                                                                                  | "Name": "Hello"                                                      |
 | PlayerInventoryContainer | PLCN           | MFF-- | Form Key or Editor ID                                                                                                         |                                                                      |
 | Relations                | XNAM           | MFFSM | JSON objects containing target Form Key/Editor ID, Reaction (Neutral, Enemy, Ally, Friend) and Modifier (Defaults to 0)       | "Relations": { "Target": "021FED:Skyrim.esm", "Reaction": "Friend" } |
 | SharedCrimeFactionList   | CRGR           | MFF-- | Form Key or Editor ID                                                                                                         |                                                                      |
+| SkyrimMajorRecordFlags   |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                     |
 | StolenGoodsContainer     | STOL           | MFF-- | Form Key or Editor ID                                                                                                         |                                                                      |
 | VendorBuySellList        | VEND           | MFF-- | Form Key or Editor ID                                                                                                         |                                                                      |
 
@@ -584,287 +724,383 @@ This just details where the field can currently be used.
 
 ## FLOR - Flora
 
-| Field                | Alt  | MFFSM | Value Type                                               | Example                         |
-| -------------------- | ---- | ----- | -------------------------------------------------------- | ------------------------------- |
-| ActivateTextOverride | RNAM | MFF-- | String value                                             | "ActivateTextOverride": "Hello" |
-| HarvestSound         | SNAM | MFF-- | Form Key or Editor ID                                    |                                 |
-| Ingredient           | PFIG | MFF-- | Form Key or Editor ID                                    |                                 |
-| Keywords             | KWDA | MFFSM | Form Keys or Editor IDs                                  |                                 |
-| Name                 | FULL | MFF-- | String value                                             | "Name": "Hello"                 |
-| ObjectBounds         | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9]   |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| ActivateTextOverride   | RNAM | MFF-- | String value                                                                                                                              | "ActivateTextOverride": "Hello"                  |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FNAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| HarvestSound           | SNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Ingredient             | PFIG | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Keywords               | KWDA | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| Name                   | FULL | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| ObjectBounds           | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| PNAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## FSTP - Footstep
 
-| Field         | Alt  | MFFSM | Value Type            | Example        |
-| ------------- | ---- | ----- | --------------------- | -------------- |
-| ImpactDataSet | DATA | MFF-- | Form Key or Editor ID |                |
-| Tag           | ANAM | MFF-- | String value          | "Tag": "Hello" |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| ImpactDataSet          | DATA | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Tag                    | ANAM | MFF-- | String value                                                                                                                              | "Tag": "Hello"                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## FSTS - FootstepSet
 
-| Field                          | Alt | MFFSM | Value Type              | Example |
-| ------------------------------ | --- | ----- | ----------------------- | ------- |
-| RunForwardAlternateFootsteps   |     | MFFSM | Form Keys or Editor IDs |         |
-| RunForwardFootsteps            |     | MFFSM | Form Keys or Editor IDs |         |
-| WalkForwardAlternateFootsteps  |     | MFFSM | Form Keys or Editor IDs |         |
-| WalkForwardAlternateFootsteps2 |     | MFFSM | Form Keys or Editor IDs |         |
-| WalkForwardFootsteps           |     | MFFSM | Form Keys or Editor IDs |         |
+| Field                          | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ------------------------------ | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID                       | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion                    |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| RunForwardAlternateFootsteps   |      | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| RunForwardFootsteps            |      | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| SkyrimMajorRecordFlags         |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| WalkForwardAlternateFootsteps  |      | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| WalkForwardAlternateFootsteps2 |      | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| WalkForwardFootsteps           |      | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
 
 [⬅ Back to Types](Types.md)
 
 ## FLST - FormList
 
-| Field | Alt                      | MFFSM | Value Type              | Example |
-| ----- | ------------------------ | ----- | ----------------------- | ------- |
-| Items | FormID;FormIDs;Item;LNAM | MFFSM | Form Keys or Editor IDs |         |
+| Field                  | Alt                      | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ------------------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID                     | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |                          | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Items                  | FormID;FormIDs;Item;LNAM | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| SkyrimMajorRecordFlags |                          | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## FURN - Furniture
 
-| Field              | Alt            | MFFSM | Value Type                                                                             | Example                                            |
-| ------------------ | -------------- | ----- | -------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| AssociatedSpell    | NAM1           | MFF-- | Form Key or Editor ID                                                                  |                                                    |
-| Flags              | DataFlags;FNAM | MF--- | Flags (IgnoredBySandbox, DisablesActivation, IsPerch, MustExitToTalk)                  | "Flags": [ "IgnoredBySandbox", "-MustExitToTalk" ] |
-| InteractionKeyword | KNAM           | MFF-- | Form Key or Editor ID                                                                  |                                                    |
-| Keywords           | KWDA           | MFFSM | Form Keys or Editor IDs                                                                |                                                    |
-| MajorFlags         | RecordFlags    | MF--- | Flags (IsPerch, HasDistantLOD, RandomAnimStart, IsMarker, MustExitToTalk, ChildCanUse) | "MajorFlags": [ "IsPerch", "-ChildCanUse" ]        |
-| Name               | FULL           | MFF-- | String value                                                                           | "Name": "Hello"                                    |
-| ObjectBounds       | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                               | "ObjectBounds": [6,6,6,9,9,9]                      |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                            |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| AssociatedSpell        | NAM1           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                    |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (IgnoredBySandbox, DisablesActivation, IsPerch, MustExitToTalk)                                                                     | "Flags": [ "IgnoredBySandbox", "-MustExitToTalk" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                   |
+| InteractionKeyword     | KNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                    |
+| Keywords               | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                    |
+| MajorFlags             | RecordFlags    | MF--- | Flags (IsPerch, HasDistantLOD, RandomAnimStart, IsMarker, MustExitToTalk, ChildCanUse)                                                    | "MajorFlags": [ "IsPerch", "-ChildCanUse" ]        |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                    |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                      |
+| PNAM                   |                | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                   |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]   |
+
+[⬅ Back to Types](Types.md)
+
+## GMST - GameSetting
+
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## GLOB - Global
 
-| Field      | Alt         | MFFSM | Value Type       | Example                  |
-| ---------- | ----------- | ----- | ---------------- | ------------------------ |
-| MajorFlags | RecordFlags | MF--- | Flags (Constant) | "MajorFlags": "Constant" |
-| TypeChar   |             | MFF-- | Numeric value    | "TypeChar": 7            |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| MajorFlags             | RecordFlags | MF--- | Flags (Constant)                                                                                                                          | "MajorFlags": "Constant"                         |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## GRAS - Grass
 
-| Field              | Alt            | MFFSM | Value Type                                                                                                                                | Example                                      |
-| ------------------ | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| ColorRange         |                | MFF-- | Decimal value                                                                                                                             | "ColorRange": 3.14                           |
-| Density            |                | MFF-- | Numeric value                                                                                                                             | "Density": 7                                 |
-| Flags              | DataFlags;FNAM | MF--- | Flags (VertexLighting, UniformScaling, FitToSlope)                                                                                        | "Flags": [ "VertexLighting", "-FitToSlope" ] |
-| HeightRange        |                | MFF-- | Decimal value                                                                                                                             | "HeightRange": 3.14                          |
-| MaxSlope           |                | MFF-- | Numeric value                                                                                                                             | "MaxSlope": 7                                |
-| MinSlope           |                | MFF-- | Numeric value                                                                                                                             | "MinSlope": 7                                |
-| ObjectBounds       | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                |
-| PositionRange      |                | MFF-- | Decimal value                                                                                                                             | "PositionRange": 3.14                        |
-| UnitsFromWater     |                | MFF-- | Numeric value                                                                                                                             | "UnitsFromWater": 7                          |
-| UnitsFromWaterType |                | MF--- | Possible values (AboveAtLeast, AboveAtMost, BelowAtLeast, BelowAtMost, EitherAtLeast, EitherAtMost, EitherAtMostAbove, EitherAtMostBelow) | "UnitsFromWaterType": "AboveAtLeast"         |
-| WavePeriod         |                | MFF-- | Decimal value                                                                                                                             | "WavePeriod": 3.14                           |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| ColorRange             |                | MFF-- | Decimal value                                                                                                                             | "ColorRange": 3.14                               |
+| Density                |                | MFF-- | Numeric value                                                                                                                             | "Density": 7                                     |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (VertexLighting, UniformScaling, FitToSlope)                                                                                        | "Flags": [ "VertexLighting", "-FitToSlope" ]     |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| HeightRange            |                | MFF-- | Decimal value                                                                                                                             | "HeightRange": 3.14                              |
+| MaxSlope               |                | MFF-- | Numeric value                                                                                                                             | "MaxSlope": 7                                    |
+| MinSlope               |                | MFF-- | Numeric value                                                                                                                             | "MinSlope": 7                                    |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| PositionRange          |                | MFF-- | Decimal value                                                                                                                             | "PositionRange": 3.14                            |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| UnitsFromWater         |                | MFF-- | Numeric value                                                                                                                             | "UnitsFromWater": 7                              |
+| UnitsFromWaterType     |                | MF--- | Possible values (AboveAtLeast, AboveAtMost, BelowAtLeast, BelowAtMost, EitherAtLeast, EitherAtMost, EitherAtMostAbove, EitherAtMostBelow) | "UnitsFromWaterType": "AboveAtLeast"             |
+| WavePeriod             |                | MFF-- | Decimal value                                                                                                                             | "WavePeriod": 3.14                               |
 
 [⬅ Back to Types](Types.md)
 
 ## HAZD - Hazard
 
-| Field              | Alt            | MFFSM | Value Type                                                                                                               | Example                                           |
-| ------------------ | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
-| Flags              | DataFlags;FNAM | MF--- | Flags (AffectsPlayerOnly, InheritDurationFromSpawnSpell, AlignToImpactNormal, InheritRadiusFromSpawnSpell, DropToGround) | "Flags": [ "AffectsPlayerOnly", "-DropToGround" ] |
-| ImageSpaceModifier | MNAM           | MFF-- | Form Key or Editor ID                                                                                                    |                                                   |
-| ImageSpaceRadius   |                | MFF-- | Decimal value                                                                                                            | "ImageSpaceRadius": 3.14                          |
-| ImpactDataSet      |                | MFF-- | Form Key or Editor ID                                                                                                    |                                                   |
-| Lifetime           |                | MFF-- | Decimal value                                                                                                            | "Lifetime": 3.14                                  |
-| Light              |                | MFF-- | Form Key or Editor ID                                                                                                    |                                                   |
-| Limit              |                | MFF-- | Numeric value                                                                                                            | "Limit": 7                                        |
-| Name               | FULL           | MFF-- | String value                                                                                                             | "Name": "Hello"                                   |
-| ObjectBounds       | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                 | "ObjectBounds": [6,6,6,9,9,9]                     |
-| Radius             |                | MFF-- | Decimal value                                                                                                            | "Radius": 3.14                                    |
-| Sound              |                | MFF-- | Form Key or Editor ID                                                                                                    |                                                   |
-| Spell              |                | MFF-- | Form Key or Editor ID                                                                                                    |                                                   |
-| TargetInterval     |                | MFF-- | Decimal value                                                                                                            | "TargetInterval": 3.14                            |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                           |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                               |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (AffectsPlayerOnly, InheritDurationFromSpawnSpell, AlignToImpactNormal, InheritRadiusFromSpawnSpell, DropToGround)                  | "Flags": [ "AffectsPlayerOnly", "-DropToGround" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                  |
+| ImageSpaceModifier     | MNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                   |
+| ImageSpaceRadius       |                | MFF-- | Decimal value                                                                                                                             | "ImageSpaceRadius": 3.14                          |
+| ImpactDataSet          |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                   |
+| Lifetime               |                | MFF-- | Decimal value                                                                                                                             | "Lifetime": 3.14                                  |
+| Light                  |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                   |
+| Limit                  |                | MFF-- | Numeric value                                                                                                                             | "Limit": 7                                        |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                   |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                     |
+| Radius                 |                | MFF-- | Decimal value                                                                                                                             | "Radius": 3.14                                    |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]  |
+| Sound                  |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                   |
+| Spell                  |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                   |
+| TargetInterval         |                | MFF-- | Decimal value                                                                                                                             | "TargetInterval": 3.14                            |
 
 [⬅ Back to Types](Types.md)
 
 ## HDPT - HeadPart
 
-| Field      | Alt             | MFFSM | Value Type                                                            | Example                                  |
-| ---------- | --------------- | ----- | --------------------------------------------------------------------- | ---------------------------------------- |
-| Color      | CNAM            | MFF-- | Form Key or Editor ID                                                 |                                          |
-| ExtraParts |                 | MFFSM | Form Keys or Editor IDs                                               |                                          |
-| Flags      | DataFlags;FNAM  | MF--- | Flags (Playable, Male, Female, IsExtraPart, UseSolidTint)             | "Flags": [ "Playable", "-UseSolidTint" ] |
-| MajorFlags | RecordFlags     | MF--- | Flags (NonPlayable)                                                   | "MajorFlags": "NonPlayable"              |
-| Name       | FULL            | MFF-- | String value                                                          | "Name": "Hello"                          |
-| TextureSet | TNAM            | MFF-- | Form Key or Editor ID                                                 |                                          |
-| Type       | PNAM            | MF--- | Possible values (Misc, Face, Eyes, Hair, FacialHair, Scars, Eyebrows) | "Type": "Misc"                           |
-| ValidRaces | Race;Races;RNAM | MFF-- | Form Key or Editor ID                                                 |                                          |
+| Field                  | Alt             | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | --------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Color                  | CNAM            | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| EditorID               | EDID            | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| ExtraParts             | HNAM            | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| Flags                  | DataFlags;FNAM  | MF--- | Flags (Playable, Male, Female, IsExtraPart, UseSolidTint)                                                                                 | "Flags": [ "Playable", "-UseSolidTint" ]         |
+| FormVersion            |                 | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| MajorFlags             | RecordFlags     | MF--- | Flags (NonPlayable)                                                                                                                       | "MajorFlags": "NonPlayable"                      |
+| Name                   | FULL            | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| SkyrimMajorRecordFlags |                 | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| TextureSet             | TNAM            | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Type                   | PNAM            | MF--- | Possible values (Misc, Face, Eyes, Hair, FacialHair, Scars, Eyebrows)                                                                     | "Type": "Misc"                                   |
+| ValidRaces             | Race;Races;RNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
 
 [⬅ Back to Types](Types.md)
 
 ## IDLE - IdleAnimation
 
-| Field                 | Alt            | MFFSM | Value Type                                      | Example                            |
-| --------------------- | -------------- | ----- | ----------------------------------------------- | ---------------------------------- |
-| AnimationEvent        | ENAM           | MFF-- | String value                                    | "AnimationEvent": "Hello"          |
-| AnimationGroupSection |                | MFF-- | Numeric value                                   | "AnimationGroupSection": 7         |
-| Flags                 | DataFlags;FNAM | MF--- | Flags (Parent, Sequence, NoAttacking, Blocking) | "Flags": [ "Parent", "-Blocking" ] |
-| LoopingSecondsMax     |                | MFF-- | Numeric value                                   | "LoopingSecondsMax": 7             |
-| LoopingSecondsMin     |                | MFF-- | Numeric value                                   | "LoopingSecondsMin": 7             |
-| RelatedIdles          |                | MFFSM | Form Keys or Editor IDs                         |                                    |
-| ReplayDelay           |                | MFF-- | Numeric value                                   | "ReplayDelay": 7                   |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AnimationEvent         | ENAM           | MFF-- | String value                                                                                                                              | "AnimationEvent": "Hello"                        |
+| AnimationGroupSection  |                | MFF-- | Numeric value                                                                                                                             | "AnimationGroupSection": 7                       |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (Parent, Sequence, NoAttacking, Blocking)                                                                                           | "Flags": [ "Parent", "-Blocking" ]               |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| LoopingSecondsMax      |                | MFF-- | Numeric value                                                                                                                             | "LoopingSecondsMax": 7                           |
+| LoopingSecondsMin      |                | MFF-- | Numeric value                                                                                                                             | "LoopingSecondsMin": 7                           |
+| RelatedIdles           | ANAM           | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| ReplayDelay            |                | MFF-- | Numeric value                                                                                                                             | "ReplayDelay": 7                                 |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## IDLM - IdleMarker
 
-| Field        | Alt                 | MFFSM | Value Type                                               | Example                                           |
-| ------------ | ------------------- | ----- | -------------------------------------------------------- | ------------------------------------------------- |
-| Animations   | IDLA                | MFFSM | Form Keys or Editor IDs                                  |                                                   |
-| Flags        | DataFlags;FNAM;IDLF | MF--- | Flags (RunInSequence, DoOnce, IgnoredBySandbox)          | "Flags": [ "RunInSequence", "-IgnoredBySandbox" ] |
-| IdleTimer    | IDLT                | MFF-- | Decimal value                                            | "IdleTimer": 3.14                                 |
-| MajorFlags   | RecordFlags         | MF--- | Flags (ChildCanUse)                                      | "MajorFlags": "ChildCanUse"                       |
-| ObjectBounds | OBND                | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9]                     |
+| Field                  | Alt                 | MFFSM | Value Type                                                                                                                                | Example                                           |
+| ---------------------- | ------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Animations             | IDLA                | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                   |
+| EditorID               | EDID                | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                               |
+| Flags                  | DataFlags;FNAM;IDLF | MF--- | Flags (RunInSequence, DoOnce, IgnoredBySandbox)                                                                                           | "Flags": [ "RunInSequence", "-IgnoredBySandbox" ] |
+| FormVersion            |                     | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                  |
+| IdleTimer              | IDLT                | MFF-- | Decimal value                                                                                                                             | "IdleTimer": 3.14                                 |
+| MajorFlags             | RecordFlags         | MF--- | Flags (ChildCanUse)                                                                                                                       | "MajorFlags": "ChildCanUse"                       |
+| ObjectBounds           | OBND                | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                     |
+| SkyrimMajorRecordFlags |                     | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]  |
 
 [⬅ Back to Types](Types.md)
 
 ## IMAD - ImageSpaceAdapter
 
-| Field               | Alt | MFFSM | Value Type                                                                                    | Example                                                 |
-| ------------------- | --- | ----- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| Animatable          |     | MFF-- | True / False                                                                                  | "Animatable": true                                      |
-| DepthOfFieldFlags   |     | MF--- | Flags (UseTarget, ModeFront, ModeBack, NoSky, BlurRadiusBit2, BlurRadiusBit1, BlurRadiusBit0) | "DepthOfFieldFlags": [ "UseTarget", "-BlurRadiusBit0" ] |
-| Duration            |     | MFF-- | Decimal value                                                                                 | "Duration": 3.14                                        |
-| RadialBlurUseTarget |     | MFF-- | True / False                                                                                  | "RadialBlurUseTarget": true                             |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                                 |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Animatable             |      | MFF-- | True / False                                                                                                                              | "Animatable": true                                      |
+| DepthOfFieldFlags      |      | MF--- | Flags (UseTarget, ModeFront, ModeBack, NoSky, BlurRadiusBit2, BlurRadiusBit1, BlurRadiusBit0)                                             | "DepthOfFieldFlags": [ "UseTarget", "-BlurRadiusBit0" ] |
+| Duration               |      | MFF-- | Decimal value                                                                                                                             | "Duration": 3.14                                        |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                     |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                        |
+| RadialBlurUseTarget    |      | MFF-- | True / False                                                                                                                              | "RadialBlurUseTarget": true                             |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]        |
+
+[⬅ Back to Types](Types.md)
+
+## IMGS - ImageSpace
+
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| ENAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+
+[⬅ Back to Types](Types.md)
+
+## IPDS - ImpactDataSet
+
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## IPCT - Impact
 
-| Field               | Alt | MFFSM | Value Type                                                              | Example                        |
-| ------------------- | --- | ----- | ----------------------------------------------------------------------- | ------------------------------ |
-| AngleThreshold      |     | MFF-- | Decimal value                                                           | "AngleThreshold": 3.14         |
-| Duration            |     | MFF-- | Decimal value                                                           | "Duration": 3.14               |
-| Hazard              |     | MFF-- | Form Key or Editor ID                                                   |                                |
-| NoDecalData         |     | MFF-- | True / False                                                            | "NoDecalData": true            |
-| Orientation         |     | MF--- | Possible values (SurfaceNormal, ProjectileVector, ProjectileReflection) | "Orientation": "SurfaceNormal" |
-| PlacementRadius     |     | MFF-- | Decimal value                                                           | "PlacementRadius": 3.14        |
-| Result              |     | MF--- | Possible values (Default, Destroy, Bounce, Impale, Stick)               | "Result": "Default"            |
-| SecondaryTextureSet |     | MFF-- | Form Key or Editor ID                                                   |                                |
-| Sound1              |     | MFF-- | Form Key or Editor ID                                                   |                                |
-| Sound2              |     | MFF-- | Form Key or Editor ID                                                   |                                |
-| SoundLevel          |     | MF--- | Possible values (Loud, Normal, Silent, VeryLoud)                        | "SoundLevel": "Loud"           |
-| TextureSet          |     | MFF-- | Form Key or Editor ID                                                   |                                |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AngleThreshold         |      | MFF-- | Decimal value                                                                                                                             | "AngleThreshold": 3.14                           |
+| Duration               |      | MFF-- | Decimal value                                                                                                                             | "Duration": 3.14                                 |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Hazard                 | NAM2 | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| NoDecalData            |      | MFF-- | True / False                                                                                                                              | "NoDecalData": true                              |
+| Orientation            |      | MF--- | Possible values (SurfaceNormal, ProjectileVector, ProjectileReflection)                                                                   | "Orientation": "SurfaceNormal"                   |
+| PlacementRadius        |      | MFF-- | Decimal value                                                                                                                             | "PlacementRadius": 3.14                          |
+| Result                 |      | MF--- | Possible values (Default, Destroy, Bounce, Impale, Stick)                                                                                 | "Result": "Default"                              |
+| SecondaryTextureSet    | ENAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Sound1                 | SNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Sound2                 | NAM1 | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SoundLevel             |      | MF--- | Possible values (Loud, Normal, Silent, VeryLoud)                                                                                          | "SoundLevel": "Loud"                             |
+| TextureSet             | DNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
 
 [⬅ Back to Types](Types.md)
 
 ## ALCH - Ingestible
 
-| Field           | Alt            | MFFSM | Value Type                                                        | Example                                                                                |
-| --------------- | -------------- | ----- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Addiction       |                | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| AddictionChance |                | MFF-- | Decimal value                                                     | "AddictionChance": 3.14                                                                |
-| ConsumeSound    |                | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| Description     | DESC           | MFF-- | String value                                                      | "Description": "Hello"                                                                 |
-| Effects         |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
-| EquipmentType   | ETYP           | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| Flags           | DataFlags;FNAM | MF--- | Flags (NoAutoCalc, FoodItem, Medicine, Poison)                    | "Flags": [ "NoAutoCalc", "-Poison" ]                                                   |
-| Keywords        | KWDA           | MFFSM | Form Keys or Editor IDs                                           |                                                                                        |
-| MajorFlags      | RecordFlags    | MF--- | Flags (Medicine)                                                  | "MajorFlags": "Medicine"                                                               |
-| Name            | FULL           | MFF-- | String value                                                      | "Name": "Hello"                                                                        |
-| ObjectBounds    | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]          | "ObjectBounds": [6,6,6,9,9,9]                                                          |
-| PickUpSound     | YNAM           | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| PutDownSound    | ZNAM           | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| Value           |                | MFF-- | Numeric value                                                     | "Value": 7                                                                             |
-| Weight          |                | MFF-- | Decimal value                                                     | "Weight": 3.14                                                                         |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                    | Example                                                                                |
+| ---------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Addiction              |                | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| AddictionChance        |                | MFF-- | Decimal value                                                                                                 | "AddictionChance": 3.14                                                                |
+| ConsumeSound           |                | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Description            | DESC           | MFF-- | String value                                                                                                  | "Description": "Hello"                                                                 |
+| EditorID               | EDID           | MFF-- | String value                                                                                                  | "EditorID": "Hello"                                                                    |
+| Effects                |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data                                             | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
+| EquipmentType          | ETYP           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (NoAutoCalc, FoodItem, Medicine, Poison)                                                                | "Flags": [ "NoAutoCalc", "-Poison" ]                                                   |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                 | "FormVersion": 7                                                                       |
+| Keywords               | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                       |                                                                                        |
+| MajorFlags             | RecordFlags    | MF--- | Flags (Medicine)                                                                                              | "MajorFlags": "Medicine"                                                               |
+| Name                   | FULL           | MFF-- | String value                                                                                                  | "Name": "Hello"                                                                        |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                      | "ObjectBounds": [6,6,6,9,9,9]                                                          |
+| PickUpSound            | YNAM           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| PutDownSound           | ZNAM           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                                       |
+| Value                  |                | MFF-- | Numeric value                                                                                                 | "Value": 7                                                                             |
+| Weight                 | DATA           | MFF-- | Decimal value                                                                                                 | "Weight": 3.14                                                                         |
 
 [⬅ Back to Types](Types.md)
 
 ## INGR - Ingredient
 
-| Field           | Alt            | MFFSM | Value Type                                                        | Example                                                                                |
-| --------------- | -------------- | ----- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Effects         |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
-| EquipType       | ETYP           | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| Flags           | DataFlags;FNAM | MF--- | Flags (NoAutoCalculation, FoodItem, ReferencesPersist)            | "Flags": [ "NoAutoCalculation", "-ReferencesPersist" ]                                 |
-| IngredientValue |                | MFF-- | Numeric value                                                     | "IngredientValue": 7                                                                   |
-| Keywords        | KWDA           | MFFSM | Form Keys or Editor IDs                                           |                                                                                        |
-| Name            | FULL           | MFF-- | String value                                                      | "Name": "Hello"                                                                        |
-| ObjectBounds    | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]          | "ObjectBounds": [6,6,6,9,9,9]                                                          |
-| PickUpSound     | YNAM           | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| PutDownSound    | ZNAM           | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| Value           |                | MFF-- | Numeric value                                                     | "Value": 7                                                                             |
-| Weight          |                | MFF-- | Decimal value                                                     | "Weight": 3.14                                                                         |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                    | Example                                                                                |
+| ---------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| EditorID               | EDID           | MFF-- | String value                                                                                                  | "EditorID": "Hello"                                                                    |
+| Effects                |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data                                             | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
+| EquipType              | ETYP           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (NoAutoCalculation, FoodItem, ReferencesPersist)                                                        | "Flags": [ "NoAutoCalculation", "-ReferencesPersist" ]                                 |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                 | "FormVersion": 7                                                                       |
+| IngredientValue        |                | MFF-- | Numeric value                                                                                                 | "IngredientValue": 7                                                                   |
+| Keywords               | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                       |                                                                                        |
+| Name                   | FULL           | MFF-- | String value                                                                                                  | "Name": "Hello"                                                                        |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                      | "ObjectBounds": [6,6,6,9,9,9]                                                          |
+| PickUpSound            | YNAM           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| PutDownSound           | ZNAM           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                                       |
+| Value                  |                | MFF-- | Numeric value                                                                                                 | "Value": 7                                                                             |
+| Weight                 |                | MFF-- | Decimal value                                                                                                 | "Weight": 3.14                                                                         |
 
 [⬅ Back to Types](Types.md)
 
 ## KEYM - Key
 
-| Field        | Alt         | MFFSM | Value Type                                               | Example                       |
-| ------------ | ----------- | ----- | -------------------------------------------------------- | ----------------------------- |
-| Keywords     | KWDA        | MFFSM | Form Keys or Editor IDs                                  |                               |
-| MajorFlags   | RecordFlags | MF--- | Flags (NonPlayable)                                      | "MajorFlags": "NonPlayable"   |
-| Name         | FULL        | MFF-- | String value                                             | "Name": "Hello"               |
-| ObjectBounds | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9] |
-| PickUpSound  | YNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| PutDownSound | ZNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| Value        |             | MFF-- | Numeric value                                            | "Value": 7                    |
-| Weight       |             | MFF-- | Decimal value                                            | "Weight": 3.14                |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Keywords               | KWDA        | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| MajorFlags             | RecordFlags | MF--- | Flags (NonPlayable)                                                                                                                       | "MajorFlags": "NonPlayable"                      |
+| Name                   | FULL        | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| ObjectBounds           | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| PickUpSound            | YNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PutDownSound           | ZNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Value                  |             | MFF-- | Numeric value                                                                                                                             | "Value": 7                                       |
+| Weight                 |             | MFF-- | Decimal value                                                                                                                             | "Weight": 3.14                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## KYWD - Keyword
 
-| Field | Alt | MFFSM | Value Type                                                                                                                                                                                                   | Example             |
-| ----- | --- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
-| Color |     | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60] |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                                    | Example                                          |
+| ---------------------- | ---- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Color                  | CNAM | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60]                              |
+| EditorID               | EDID | MFF-- | String value                                                                                                                                                  | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                                                 | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)                     | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## LTEX - LandscapeTexture
 
-| Field                   | Alt            | MFFSM | Value Type              | Example                      |
-| ----------------------- | -------------- | ----- | ----------------------- | ---------------------------- |
-| Flags                   | DataFlags;FNAM | MF--- | Flags (IsSnow)          | "Flags": "IsSnow"            |
-| Grasses                 |                | MFFSM | Form Keys or Editor IDs |                              |
-| HavokFriction           |                | MFF-- | Numeric value           | "HavokFriction": 7           |
-| HavokRestitution        |                | MFF-- | Numeric value           | "HavokRestitution": 7        |
-| MaterialType            |                | MFF-- | Form Key or Editor ID   |                              |
-| TextureSet              |                | MFF-- | Form Key or Editor ID   |                              |
-| TextureSpecularExponent |                | MFF-- | Numeric value           | "TextureSpecularExponent": 7 |
+| Field                   | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ----------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID                | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| Flags                   | DataFlags;FNAM | MF--- | Flags (IsSnow)                                                                                                                            | "Flags": "IsSnow"                                |
+| FormVersion             |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Grasses                 | GNAM           | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| HavokFriction           |                | MFF-- | Numeric value                                                                                                                             | "HavokFriction": 7                               |
+| HavokRestitution        |                | MFF-- | Numeric value                                                                                                                             | "HavokRestitution": 7                            |
+| MaterialType            | MNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags  |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| TextureSet              | TNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| TextureSpecularExponent | SNAM           | MFF-- | Numeric value                                                                                                                             | "TextureSpecularExponent": 7                     |
 
 [⬅ Back to Types](Types.md)
 
 ## LVLI - LeveledItem
 
-| Field        | Alt            | MFFSM | Value Type                                                                                            | Example                                                                    |
-| ------------ | -------------- | ----- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| ChanceNone   |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                              | "ChanceNone": "30.5%"                                                      |
-| Entries      |                | MFFSM | Array of JSON objects containing Item Form Key/Editor ID and level/count data                         | "Entries": [{ "Item": "000ABC:Skyrim.esm", "Level": 36, "Count": 1 }]      |
-| Flags        | DataFlags;FNAM | MF--- | Flags (CalculateFromAllLevelsLessThanOrEqualPlayer, CalculateForEachItemInCount, UseAll, SpecialLoot) | "Flags": [ "CalculateFromAllLevelsLessThanOrEqualPlayer", "-SpecialLoot" ] |
-| Global       |                | MFF-- | Form Key or Editor ID                                                                                 |                                                                            |
-| ObjectBounds | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                              | "ObjectBounds": [6,6,6,9,9,9]                                              |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                | Example                                                                    |
+| ---------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| ChanceNone             | LVLD           | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                  | "ChanceNone": "30.5%"                                                      |
+| EditorID               | EDID           | MFF-- | String value                                                                                                              | "EditorID": "Hello"                                                        |
+| Entries                |                | MFFSM | Array of JSON objects containing Item Form Key/Editor ID and level/count data                                             | "Entries": [{ "Item": "000ABC:Skyrim.esm", "Level": 36, "Count": 1 }]      |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (CalculateFromAllLevelsLessThanOrEqualPlayer, CalculateForEachItemInCount, UseAll, SpecialLoot)                     | "Flags": [ "CalculateFromAllLevelsLessThanOrEqualPlayer", "-SpecialLoot" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                             | "FormVersion": 7                                                           |
+| Global                 | LVLG           | MFF-- | Form Key or Editor ID                                                                                                     |                                                                            |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                  | "ObjectBounds": [6,6,6,9,9,9]                                              |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                           |
 
 [⬅ Back to Types](Types.md)
 
 ## LVLN - LeveledNpc
 
-| Field        | Alt            | MFFSM | Value Type                                                                       | Example                                                                                    |
-| ------------ | -------------- | ----- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| ChanceNone   |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                         | "ChanceNone": "30.5%"                                                                      |
-| Entries      |                | MFFSM | Array of JSON objects containing NPC Form Key/Editor ID and level/count data     | "Entries": [{ "NPC": "000ABC:Skyrim.esm", "Level": 36, "Count": 1 }]                       |
-| Flags        | DataFlags;FNAM | MF--- | Flags (CalculateFromAllLevelsLessThanOrEqualPlayer, CalculateForEachItemInCount) | "Flags": [ "CalculateFromAllLevelsLessThanOrEqualPlayer", "-CalculateForEachItemInCount" ] |
-| Global       |                | MFF-- | Form Key or Editor ID                                                            |                                                                                            |
-| ObjectBounds | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                         | "ObjectBounds": [6,6,6,9,9,9]                                                              |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                | Example                                                                                    |
+| ---------------------- | -------------- | ----- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| ChanceNone             | LVLD           | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                  | "ChanceNone": "30.5%"                                                                      |
+| EditorID               | EDID           | MFF-- | String value                                                                                              | "EditorID": "Hello"                                                                        |
+| Entries                |                | MFFSM | Array of JSON objects containing NPC Form Key/Editor ID and level/count data                              | "Entries": [{ "NPC": "000ABC:Skyrim.esm", "Level": 36, "Count": 1 }]                       |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (CalculateFromAllLevelsLessThanOrEqualPlayer, CalculateForEachItemInCount)                          | "Flags": [ "CalculateFromAllLevelsLessThanOrEqualPlayer", "-CalculateForEachItemInCount" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                             | "FormVersion": 7                                                                           |
+| Global                 | LVLG           | MFF-- | Form Key or Editor ID                                                                                     |                                                                                            |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                  | "ObjectBounds": [6,6,6,9,9,9]                                                              |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                                           |
 
 [⬅ Back to Types](Types.md)
 
 ## LVSP - LeveledSpell
 
-| Field        | Alt            | MFFSM | Value Type                                                                                     | Example                                                                     |
-| ------------ | -------------- | ----- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| ChanceNone   |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                       | "ChanceNone": "30.5%"                                                       |
-| Entries      |                | MFFSM | Array of JSON objects containing Spell Form Key/Editor ID and level/count data                 | "Entries": [{ "Spell": "000ABC:Skyrim.esm", "Level": 36, "Count": 1 }]      |
-| Flags        | DataFlags;FNAM | MF--- | Flags (CalculateFromAllLevelsLessThanOrEqualPlayer, CalculateForEachItemInCount, UseAllSpells) | "Flags": [ "CalculateFromAllLevelsLessThanOrEqualPlayer", "-UseAllSpells" ] |
-| ObjectBounds | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                       | "ObjectBounds": [6,6,6,9,9,9]                                               |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                               | Example                                                                     |
+| ---------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| ChanceNone             | LVLD           | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                 | "ChanceNone": "30.5%"                                                       |
+| EditorID               | EDID           | MFF-- | String value                                                                                                             | "EditorID": "Hello"                                                         |
+| Entries                |                | MFFSM | Array of JSON objects containing Spell Form Key/Editor ID and level/count data                                           | "Entries": [{ "Spell": "000ABC:Skyrim.esm", "Level": 36, "Count": 1 }]      |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (CalculateFromAllLevelsLessThanOrEqualPlayer, CalculateForEachItemInCount, UseAllSpells)                           | "Flags": [ "CalculateFromAllLevelsLessThanOrEqualPlayer", "-UseAllSpells" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                            | "FormVersion": 7                                                            |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                 | "ObjectBounds": [6,6,6,9,9,9]                                               |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                            |
 
 [⬅ Back to Types](Types.md)
 
@@ -873,20 +1109,23 @@ This just details where the field can currently be used.
 | Field                     | Alt            | MFFSM | Value Type                                                                                                                                       | Example                                          |
 | ------------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
 | Color                     |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60]                              |
-| FadeValue                 |                | MFF-- | Decimal value                                                                                                                                    | "FadeValue": 3.14                                |
+| EditorID                  | EDID           | MFF-- | String value                                                                                                                                     | "EditorID": "Hello"                              |
+| FadeValue                 | FNAM           | MFF-- | Decimal value                                                                                                                                    | "FadeValue": 3.14                                |
 | FalloffExponent           |                | MFF-- | Decimal value                                                                                                                                    | "FalloffExponent": 3.14                          |
 | Flags                     | DataFlags;FNAM | MF--- | Flags (Dynamic, CanBeCarried, Negative, Flicker, OffByDefault, FlickerSlow, Pulse, PulseSlow, SpotLight, ShadowSpotlight, ShadowHemisphere, ShadowOmnidirectional, PortalStrict) | "Flags": [ "Dynamic", "-PortalStrict" ]          |
 | FlickerIntensityAmplitude |                | MFF-- | Decimal value                                                                                                                                    | "FlickerIntensityAmplitude": 3.14                |
 | FlickerMovementAmplitude  |                | MFF-- | Decimal value                                                                                                                                    | "FlickerMovementAmplitude": 3.14                 |
 | FlickerPeriod             |                | MFF-- | Decimal value                                                                                                                                    | "FlickerPeriod": 3.14                            |
+| FormVersion               |                | MFF-- | Numeric value                                                                                                                                    | "FormVersion": 7                                 |
 | FOV                       |                | MFF-- | Decimal value                                                                                                                                    | "FOV": 3.14                                      |
-| Lens                      |                | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| Lens                      | LNAM           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
 | MajorFlags                | RecordFlags    | MF--- | Flags (RandomAnimStart, PortalStrict, Obstacle)                                                                                                  | "MajorFlags": [ "RandomAnimStart", "-Obstacle" ] |
 | Name                      | FULL           | MFF-- | String value                                                                                                                                     | "Name": "Hello"                                  |
 | NearClip                  |                | MFF-- | Decimal value                                                                                                                                    | "NearClip": 3.14                                 |
 | ObjectBounds              | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                         | "ObjectBounds": [6,6,6,9,9,9]                    |
 | Radius                    |                | MFF-- | Numeric value                                                                                                                                    | "Radius": 7                                      |
-| Sound                     |                | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| SkyrimMajorRecordFlags    |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)        | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Sound                     | SNAM           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
 | Time                      |                | MFF-- | Numeric value                                                                                                                                    | "Time": 7                                        |
 | Value                     |                | MFF-- | Numeric value                                                                                                                                    | "Value": 7                                       |
 | Weight                    |                | MFF-- | Decimal value                                                                                                                                    | "Weight": 3.14                                   |
@@ -895,217 +1134,257 @@ This just details where the field can currently be used.
 
 ## LGTM - LightingTemplate
 
-| Field                  | Alt | MFFSM | Value Type                                                                                                                                                                       | Example                        |
-| ---------------------- | --- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| AmbientColor           |     | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "AmbientColor": [40,50,60]     |
-| DirectionalColor       |     | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "DirectionalColor": [40,50,60] |
-| DirectionalFade        |     | MFF-- | Decimal value                                                                                                                                                                    | "DirectionalFade": 3.14        |
-| DirectionalRotationXY  |     | MFF-- | Numeric value                                                                                                                                                                    | "DirectionalRotationXY": 7     |
-| DirectionalRotationZ   |     | MFF-- | Numeric value                                                                                                                                                                    | "DirectionalRotationZ": 7      |
-| FogClipDistance        |     | MFF-- | Decimal value                                                                                                                                                                    | "FogClipDistance": 3.14        |
-| FogFar                 |     | MFF-- | Decimal value                                                                                                                                                                    | "FogFar": 3.14                 |
-| FogFarColor            |     | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "FogFarColor": [40,50,60]      |
-| FogMax                 |     | MFF-- | Decimal value                                                                                                                                                                    | "FogMax": 3.14                 |
-| FogNear                |     | MFF-- | Decimal value                                                                                                                                                                    | "FogNear": 3.14                |
-| FogNearColor           |     | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "FogNearColor": [40,50,60]     |
-| FogPower               |     | MFF-- | Decimal value                                                                                                                                                                    | "FogPower": 3.14               |
-| LightFadeEndDistance   |     | MFF-- | Decimal value                                                                                                                                                                    | "LightFadeEndDistance": 3.14   |
-| LightFadeStartDistance |     | MFF-- | Decimal value                                                                                                                                                                    | "LightFadeStartDistance": 3.14 |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                                    | Example                                          |
+| ---------------------- | ---- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AmbientColor           |      | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "AmbientColor": [40,50,60]                       |
+| DirectionalColor       |      | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "DirectionalColor": [40,50,60]                   |
+| DirectionalFade        |      | MFF-- | Decimal value                                                                                                                                                 | "DirectionalFade": 3.14                          |
+| DirectionalRotationXY  |      | MFF-- | Numeric value                                                                                                                                                 | "DirectionalRotationXY": 7                       |
+| DirectionalRotationZ   |      | MFF-- | Numeric value                                                                                                                                                 | "DirectionalRotationZ": 7                        |
+| EditorID               | EDID | MFF-- | String value                                                                                                                                                  | "EditorID": "Hello"                              |
+| FogClipDistance        |      | MFF-- | Decimal value                                                                                                                                                 | "FogClipDistance": 3.14                          |
+| FogFar                 |      | MFF-- | Decimal value                                                                                                                                                 | "FogFar": 3.14                                   |
+| FogFarColor            |      | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "FogFarColor": [40,50,60]                        |
+| FogMax                 |      | MFF-- | Decimal value                                                                                                                                                 | "FogMax": 3.14                                   |
+| FogNear                |      | MFF-- | Decimal value                                                                                                                                                 | "FogNear": 3.14                                  |
+| FogNearColor           |      | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "FogNearColor": [40,50,60]                       |
+| FogPower               |      | MFF-- | Decimal value                                                                                                                                                 | "FogPower": 3.14                                 |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                                                 | "FormVersion": 7                                 |
+| LightFadeEndDistance   |      | MFF-- | Decimal value                                                                                                                                                 | "LightFadeEndDistance": 3.14                     |
+| LightFadeStartDistance |      | MFF-- | Decimal value                                                                                                                                                 | "LightFadeStartDistance": 3.14                   |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)                     | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## LSCR - LoadScreen
 
-| Field            | Alt         | MFFSM | Value Type                 | Example                            |
-| ---------------- | ----------- | ----- | -------------------------- | ---------------------------------- |
-| Description      | DESC        | MFF-- | String value               | "Description": "Hello"             |
-| InitialScale     |             | MFF-- | Decimal value              | "InitialScale": 3.14               |
-| LoadingScreenNif |             | MFF-- | Form Key or Editor ID      |                                    |
-| MajorFlags       | RecordFlags | MF--- | Flags (DisplaysInMainMenu) | "MajorFlags": "DisplaysInMainMenu" |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Description            | DESC        | MFF-- | String value                                                                                                                              | "Description": "Hello"                           |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| InitialScale           | SNAM        | MFF-- | Decimal value                                                                                                                             | "InitialScale": 3.14                             |
+| LoadingScreenNif       | NNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| MajorFlags             | RecordFlags | MF--- | Flags (DisplaysInMainMenu)                                                                                                                | "MajorFlags": "DisplaysInMainMenu"               |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## LCTN - Location
 
-| Field                             | Alt  | MFFSM | Value Type                                                                                                                                                              | Example                     |
-| --------------------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| ActorCellMarkerReference          |      | MFFSM | Form Keys or Editor IDs                                                                                                                                                 |                             |
-| Color                             |      | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60]         |
-| HorseMarkerRef                    |      | MFF-- | Form Key or Editor ID                                                                                                                                                   |                             |
-| Keywords                          | KWDA | MFFSM | Form Keys or Editor IDs                                                                                                                                                 |                             |
-| LocationCellMarkerReference       |      | MFFSM | Form Keys or Editor IDs                                                                                                                                                 |                             |
-| Music                             |      | MFF-- | Form Key or Editor ID                                                                                                                                                   |                             |
-| Name                              | FULL | MFF-- | String value                                                                                                                                                            | "Name": "Hello"             |
-| ParentLocation                    |      | MFF-- | Form Key or Editor ID                                                                                                                                                   |                             |
-| ReferenceCellPersistentReferences |      | MFFSM | Form Keys or Editor IDs                                                                                                                                                 |                             |
-| ReferenceCellStaticReferences     |      | MFFSM | Form Keys or Editor IDs                                                                                                                                                 |                             |
-| ReferenceCellUnique               |      | MFFSM | Form Keys or Editor IDs                                                                                                                                                 |                             |
-| UnreportedCrimeFaction            |      | MFF-- | Form Key or Editor ID                                                                                                                                                   |                             |
-| WorldLocationMarkerRef            |      | MFF-- | Form Key or Editor ID                                                                                                                                                   |                             |
-| WorldLocationRadius               |      | MFF-- | Decimal value                                                                                                                                                           | "WorldLocationRadius": 3.14 |
+| Field                             | Alt  | MFFSM | Value Type                                                                                                                                         | Example                                          |
+| --------------------------------- | ---- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| ActorCellMarkerReference          |      | MFFSM | Form Keys or Editor IDs                                                                                                                            |                                                  |
+| Color                             | CNAM | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60]                              |
+| EditorID                          | EDID | MFF-- | String value                                                                                                                                       | "EditorID": "Hello"                              |
+| FormVersion                       |      | MFF-- | Numeric value                                                                                                                                      | "FormVersion": 7                                 |
+| HorseMarkerRef                    | NAM0 | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| Keywords                          | KWDA | MFFSM | Form Keys or Editor IDs                                                                                                                            |                                                  |
+| LocationCellMarkerReference       |      | MFFSM | Form Keys or Editor IDs                                                                                                                            |                                                  |
+| Music                             | NAM1 | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| Name                              | FULL | MFF-- | String value                                                                                                                                       | "Name": "Hello"                                  |
+| ParentLocation                    | PNAM | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| ReferenceCellPersistentReferences |      | MFFSM | Form Keys or Editor IDs                                                                                                                            |                                                  |
+| ReferenceCellStaticReferences     |      | MFFSM | Form Keys or Editor IDs                                                                                                                            |                                                  |
+| ReferenceCellUnique               |      | MFFSM | Form Keys or Editor IDs                                                                                                                            |                                                  |
+| SkyrimMajorRecordFlags            |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)          | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| UnreportedCrimeFaction            | FNAM | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| WorldLocationMarkerRef            | MNAM | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| WorldLocationRadius               | RNAM | MFF-- | Decimal value                                                                                                                                      | "WorldLocationRadius": 3.14                      |
 
 [⬅ Back to Types](Types.md)
 
 ## LCRT - LocationReferenceType
 
-| Field | Alt | MFFSM | Value Type                                                                                                                                                                                                   | Example             |
-| ----- | --- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
-| Color |     | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60] |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                                    | Example                                          |
+| ---------------------- | ---- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Color                  | CNAM | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "Color": [40,50,60]                              |
+| EditorID               | EDID | MFF-- | String value                                                                                                                                                  | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                                                 | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)                     | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## MGEF - MagicEffect
 
-| Field                   | Alt            | MFFSM | Value Type                                                                                                                                                 | Example                                  |
-| ----------------------- | -------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| BaseCost                |                | MFF-- | Decimal value                                                                                                                                              | "BaseCost": 3.14                         |
-| CastingArt              |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| CastingLight            |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| CastingSoundLevel       |                | MF--- | Possible values (Loud, Normal, Silent, VeryLoud)                                                                                                           | "CastingSoundLevel": "Loud"              |
-| CastType                |                | MF--- | Possible values (ConstantEffect, FireAndForget, Concentration)                                                                                             | "CastType": "ConstantEffect"             |
-| CounterEffects          |                | MFFSM | Form Keys or Editor IDs                                                                                                                                    |                                          |
-| Description             | DESC           | MFF-- | String value                                                                                                                                               | "Description": "Hello"                   |
-| DualCastArt             |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| DualCastScale           |                | MFF-- | Decimal value                                                                                                                                              | "DualCastScale": 3.14                    |
-| EnchantArt              |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| EnchantShader           |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| EnchantVisuals          |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| EquipAbility            |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| Explosion               |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| Flags                   | DataFlags;FNAM | MF--- | Flags (Hostile, Recover, Detrimental, SnapToNavmesh, NoHitEvent, DispelWithKeywords, NoDuration, NoMagnitude, NoArea, FXPersist, GoryVisuals, HideInUI, NoRecast, PowerAffectsMagnitude, PowerAffectsDuration, Painless, NoHitEffect, NoDeathDispel) | "Flags": [ "Hostile", "-NoDeathDispel" ] |
-| HitEffectArt            |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| HitShader               |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| HitVisuals              |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| ImageSpaceModifier      |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| ImpactData              |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| Keywords                | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                                                                    |                                          |
-| MagicSkill              |                | MF--- | Possible values (Aggression, Confidence, Energy, Morality, Mood, Assistance, OneHanded, TwoHanded, Archery, Block, Smithing, HeavyArmor, LightArmor, Pickpocket, Lockpicking, Sneak, Alchemy, Speech, Alteration, Conjuration, Destruction, Illusion, Restoration, Enchanting, Health, Magicka, Stamina, HealRate, MagickaRate, StaminaRate, SpeedMult, InventoryWeight, CarryWeight, CriticalChance, MeleeDamage, UnarmedDamage, Mass, VoicePoints, VoiceRate, DamageResist, PoisonResist, ResistFire, ResistShock, ResistFrost, ResistMagic, ResistDisease, Paralysis, Invisibility, NightEye, DetectLifeRange, WaterBreathing, WaterWalking, Fame, Infamy, JumpingBonus, WardPower, RightItemCharge, ArmorPerks, ShieldPerks, WardDeflection, Variable01, Variable02, Variable03, Variable04, Variable05, Variable06, Variable07, Variable08, Variable09, Variable10, BowSpeedBonus, FavorActive, FavorsPerDay, FavorsPerDayTimer, LeftItemCharge, AbsorbChance, Blindness, WeaponSpeedMult, ShoutRecoveryMult, BowStaggerBonus, Telekinesis, FavorPointsBonus, LastBribedIntimidated, LastFlattered, MovementNoiseMult, BypassVendorStolenCheck, BypassVendorKeywordCheck, WaitingForPlayer, OneHandedModifier, TwoHandedModifier, MarksmanModifier, BlockModifier, SmithingModifier, HeavyArmorModifier, LightArmorModifier, PickpocketModifier, LockpickingModifier, SneakingModifier, AlchemyModifier, SpeechcraftModifier, AlterationModifier, ConjurationModifier, DestructionModifier, IllusionModifier, RestorationModifier, EnchantingModifier, OneHandedSkillAdvance, TwoHandedSkillAdvance, MarksmanSkillAdvance, BlockSkillAdvance, SmithingSkillAdvance, HeavyArmorSkillAdvance, LightArmorSkillAdvance, PickpocketSkillAdvance, LockpickingSkillAdvance, SneakingSkillAdvance, AlchemySkillAdvance, SpeechcraftSkillAdvance, AlterationSkillAdvance, ConjurationSkillAdvance, DestructionSkillAdvance, IllusionSkillAdvance, RestorationSkillAdvance, EnchantingSkillAdvance, LeftWeaponSpeedMultiply, DragonSouls, CombatHealthRegenMultiply, OneHandedPowerModifier, TwoHandedPowerModifier, MarksmanPowerModifier, BlockPowerModifier, SmithingPowerModifier, HeavyArmorPowerModifier, LightArmorPowerModifier, PickpocketPowerModifier, LockpickingPowerModifier, SneakingPowerModifier, AlchemyPowerModifier, SpeechcraftPowerModifier, AlterationPowerModifier, ConjurationPowerModifier, DestructionPowerModifier, IllusionPowerModifier, RestorationPowerModifier, EnchantingPowerModifier, DragonRend, AttackDamageMult, HealRateMult, MagickaRateMult, StaminaRateMult, WerewolfPerks, VampirePerks, GrabActorOffset, Grabbed, ReflectDamage, None) | "MagicSkill": "Aggression"               |
-| MenuDisplayObject       |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| MinimumSkillLevel       |                | MFF-- | Numeric value                                                                                                                                              | "MinimumSkillLevel": 7                   |
-| Name                    | FULL           | MFF-- | String value                                                                                                                                               | "Name": "Hello"                          |
-| PerkToApply             |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| Projectile              |                | MFF-- | Form Key or Editor ID                                                                                                                                      |                                          |
-| ResistValue             |                | MF--- | Possible values (Aggression, Confidence, Energy, Morality, Mood, Assistance, OneHanded, TwoHanded, Archery, Block, Smithing, HeavyArmor, LightArmor, Pickpocket, Lockpicking, Sneak, Alchemy, Speech, Alteration, Conjuration, Destruction, Illusion, Restoration, Enchanting, Health, Magicka, Stamina, HealRate, MagickaRate, StaminaRate, SpeedMult, InventoryWeight, CarryWeight, CriticalChance, MeleeDamage, UnarmedDamage, Mass, VoicePoints, VoiceRate, DamageResist, PoisonResist, ResistFire, ResistShock, ResistFrost, ResistMagic, ResistDisease, Paralysis, Invisibility, NightEye, DetectLifeRange, WaterBreathing, WaterWalking, Fame, Infamy, JumpingBonus, WardPower, RightItemCharge, ArmorPerks, ShieldPerks, WardDeflection, Variable01, Variable02, Variable03, Variable04, Variable05, Variable06, Variable07, Variable08, Variable09, Variable10, BowSpeedBonus, FavorActive, FavorsPerDay, FavorsPerDayTimer, LeftItemCharge, AbsorbChance, Blindness, WeaponSpeedMult, ShoutRecoveryMult, BowStaggerBonus, Telekinesis, FavorPointsBonus, LastBribedIntimidated, LastFlattered, MovementNoiseMult, BypassVendorStolenCheck, BypassVendorKeywordCheck, WaitingForPlayer, OneHandedModifier, TwoHandedModifier, MarksmanModifier, BlockModifier, SmithingModifier, HeavyArmorModifier, LightArmorModifier, PickpocketModifier, LockpickingModifier, SneakingModifier, AlchemyModifier, SpeechcraftModifier, AlterationModifier, ConjurationModifier, DestructionModifier, IllusionModifier, RestorationModifier, EnchantingModifier, OneHandedSkillAdvance, TwoHandedSkillAdvance, MarksmanSkillAdvance, BlockSkillAdvance, SmithingSkillAdvance, HeavyArmorSkillAdvance, LightArmorSkillAdvance, PickpocketSkillAdvance, LockpickingSkillAdvance, SneakingSkillAdvance, AlchemySkillAdvance, SpeechcraftSkillAdvance, AlterationSkillAdvance, ConjurationSkillAdvance, DestructionSkillAdvance, IllusionSkillAdvance, RestorationSkillAdvance, EnchantingSkillAdvance, LeftWeaponSpeedMultiply, DragonSouls, CombatHealthRegenMultiply, OneHandedPowerModifier, TwoHandedPowerModifier, MarksmanPowerModifier, BlockPowerModifier, SmithingPowerModifier, HeavyArmorPowerModifier, LightArmorPowerModifier, PickpocketPowerModifier, LockpickingPowerModifier, SneakingPowerModifier, AlchemyPowerModifier, SpeechcraftPowerModifier, AlterationPowerModifier, ConjurationPowerModifier, DestructionPowerModifier, IllusionPowerModifier, RestorationPowerModifier, EnchantingPowerModifier, DragonRend, AttackDamageMult, HealRateMult, MagickaRateMult, StaminaRateMult, WerewolfPerks, VampirePerks, GrabActorOffset, Grabbed, ReflectDamage, None) | "ResistValue": "Aggression"              |
-| ScriptEffectAIDelayTime |                | MFF-- | Decimal value                                                                                                                                              | "ScriptEffectAIDelayTime": 3.14          |
-| ScriptEffectAIScore     |                | MFF-- | Decimal value                                                                                                                                              | "ScriptEffectAIScore": 3.14              |
-| SecondActorValue        |                | MF--- | Possible values (Aggression, Confidence, Energy, Morality, Mood, Assistance, OneHanded, TwoHanded, Archery, Block, Smithing, HeavyArmor, LightArmor, Pickpocket, Lockpicking, Sneak, Alchemy, Speech, Alteration, Conjuration, Destruction, Illusion, Restoration, Enchanting, Health, Magicka, Stamina, HealRate, MagickaRate, StaminaRate, SpeedMult, InventoryWeight, CarryWeight, CriticalChance, MeleeDamage, UnarmedDamage, Mass, VoicePoints, VoiceRate, DamageResist, PoisonResist, ResistFire, ResistShock, ResistFrost, ResistMagic, ResistDisease, Paralysis, Invisibility, NightEye, DetectLifeRange, WaterBreathing, WaterWalking, Fame, Infamy, JumpingBonus, WardPower, RightItemCharge, ArmorPerks, ShieldPerks, WardDeflection, Variable01, Variable02, Variable03, Variable04, Variable05, Variable06, Variable07, Variable08, Variable09, Variable10, BowSpeedBonus, FavorActive, FavorsPerDay, FavorsPerDayTimer, LeftItemCharge, AbsorbChance, Blindness, WeaponSpeedMult, ShoutRecoveryMult, BowStaggerBonus, Telekinesis, FavorPointsBonus, LastBribedIntimidated, LastFlattered, MovementNoiseMult, BypassVendorStolenCheck, BypassVendorKeywordCheck, WaitingForPlayer, OneHandedModifier, TwoHandedModifier, MarksmanModifier, BlockModifier, SmithingModifier, HeavyArmorModifier, LightArmorModifier, PickpocketModifier, LockpickingModifier, SneakingModifier, AlchemyModifier, SpeechcraftModifier, AlterationModifier, ConjurationModifier, DestructionModifier, IllusionModifier, RestorationModifier, EnchantingModifier, OneHandedSkillAdvance, TwoHandedSkillAdvance, MarksmanSkillAdvance, BlockSkillAdvance, SmithingSkillAdvance, HeavyArmorSkillAdvance, LightArmorSkillAdvance, PickpocketSkillAdvance, LockpickingSkillAdvance, SneakingSkillAdvance, AlchemySkillAdvance, SpeechcraftSkillAdvance, AlterationSkillAdvance, ConjurationSkillAdvance, DestructionSkillAdvance, IllusionSkillAdvance, RestorationSkillAdvance, EnchantingSkillAdvance, LeftWeaponSpeedMultiply, DragonSouls, CombatHealthRegenMultiply, OneHandedPowerModifier, TwoHandedPowerModifier, MarksmanPowerModifier, BlockPowerModifier, SmithingPowerModifier, HeavyArmorPowerModifier, LightArmorPowerModifier, PickpocketPowerModifier, LockpickingPowerModifier, SneakingPowerModifier, AlchemyPowerModifier, SpeechcraftPowerModifier, AlterationPowerModifier, ConjurationPowerModifier, DestructionPowerModifier, IllusionPowerModifier, RestorationPowerModifier, EnchantingPowerModifier, DragonRend, AttackDamageMult, HealRateMult, MagickaRateMult, StaminaRateMult, WerewolfPerks, VampirePerks, GrabActorOffset, Grabbed, ReflectDamage, None) | "SecondActorValue": "Aggression"         |
-| SecondActorValueWeight  |                | MFF-- | Decimal value                                                                                                                                              | "SecondActorValueWeight": 3.14           |
-| SkillUsageMultiplier    |                | MFF-- | Decimal value                                                                                                                                              | "SkillUsageMultiplier": 3.14             |
-| SpellmakingArea         |                | MFF-- | Numeric value                                                                                                                                              | "SpellmakingArea": 7                     |
-| SpellmakingCastingTime  |                | MFF-- | Decimal value                                                                                                                                              | "SpellmakingCastingTime": 3.14           |
-| TaperCurve              |                | MFF-- | Decimal value                                                                                                                                              | "TaperCurve": 3.14                       |
-| TaperDuration           |                | MFF-- | Decimal value                                                                                                                                              | "TaperDuration": 3.14                    |
-| TaperWeight             |                | MFF-- | Decimal value                                                                                                                                              | "TaperWeight": 3.14                      |
-| TargetType              |                | MF--- | Possible values (Self, Touch, Aimed, TargetActor, TargetLocation)                                                                                          | "TargetType": "Self"                     |
-| Unknown1                |                | MFF-- | Numeric value                                                                                                                                              | "Unknown1": 7                            |
+| Field                   | Alt            | MFFSM | Value Type                                                                                                                                         | Example                                          |
+| ----------------------- | -------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| BaseCost                |                | MFF-- | Decimal value                                                                                                                                      | "BaseCost": 3.14                                 |
+| CastingArt              |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| CastingLight            |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| CastingSoundLevel       |                | MF--- | Possible values (Loud, Normal, Silent, VeryLoud)                                                                                                   | "CastingSoundLevel": "Loud"                      |
+| CastType                |                | MF--- | Possible values (ConstantEffect, FireAndForget, Concentration)                                                                                     | "CastType": "ConstantEffect"                     |
+| CounterEffects          |                | MFFSM | Form Keys or Editor IDs                                                                                                                            |                                                  |
+| Description             | DESC;DNAM      | MFF-- | String value                                                                                                                                       | "Description": "Hello"                           |
+| DualCastArt             |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| DualCastScale           |                | MFF-- | Decimal value                                                                                                                                      | "DualCastScale": 3.14                            |
+| EditorID                | EDID           | MFF-- | String value                                                                                                                                       | "EditorID": "Hello"                              |
+| EnchantArt              |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| EnchantShader           |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| EnchantVisuals          |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| EquipAbility            |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| Explosion               |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| Flags                   | DataFlags;FNAM | MF--- | Flags (Hostile, Recover, Detrimental, SnapToNavmesh, NoHitEvent, DispelWithKeywords, NoDuration, NoMagnitude, NoArea, FXPersist, GoryVisuals, HideInUI, NoRecast, PowerAffectsMagnitude, PowerAffectsDuration, Painless, NoHitEffect, NoDeathDispel) | "Flags": [ "Hostile", "-NoDeathDispel" ]         |
+| FormVersion             |                | MFF-- | Numeric value                                                                                                                                      | "FormVersion": 7                                 |
+| HitEffectArt            |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| HitShader               |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| HitVisuals              |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| ImageSpaceModifier      |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| ImpactData              |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| Keywords                | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                                                            |                                                  |
+| MagicSkill              |                | MF--- | Possible values (Aggression, Confidence, Energy, Morality, Mood, Assistance, OneHanded, TwoHanded, Archery, Block, Smithing, HeavyArmor, LightArmor, Pickpocket, Lockpicking, Sneak, Alchemy, Speech, Alteration, Conjuration, Destruction, Illusion, Restoration, Enchanting, Health, Magicka, Stamina, HealRate, MagickaRate, StaminaRate, SpeedMult, InventoryWeight, CarryWeight, CriticalChance, MeleeDamage, UnarmedDamage, Mass, VoicePoints, VoiceRate, DamageResist, PoisonResist, ResistFire, ResistShock, ResistFrost, ResistMagic, ResistDisease, Paralysis, Invisibility, NightEye, DetectLifeRange, WaterBreathing, WaterWalking, Fame, Infamy, JumpingBonus, WardPower, RightItemCharge, ArmorPerks, ShieldPerks, WardDeflection, Variable01, Variable02, Variable03, Variable04, Variable05, Variable06, Variable07, Variable08, Variable09, Variable10, BowSpeedBonus, FavorActive, FavorsPerDay, FavorsPerDayTimer, LeftItemCharge, AbsorbChance, Blindness, WeaponSpeedMult, ShoutRecoveryMult, BowStaggerBonus, Telekinesis, FavorPointsBonus, LastBribedIntimidated, LastFlattered, MovementNoiseMult, BypassVendorStolenCheck, BypassVendorKeywordCheck, WaitingForPlayer, OneHandedModifier, TwoHandedModifier, MarksmanModifier, BlockModifier, SmithingModifier, HeavyArmorModifier, LightArmorModifier, PickpocketModifier, LockpickingModifier, SneakingModifier, AlchemyModifier, SpeechcraftModifier, AlterationModifier, ConjurationModifier, DestructionModifier, IllusionModifier, RestorationModifier, EnchantingModifier, OneHandedSkillAdvance, TwoHandedSkillAdvance, MarksmanSkillAdvance, BlockSkillAdvance, SmithingSkillAdvance, HeavyArmorSkillAdvance, LightArmorSkillAdvance, PickpocketSkillAdvance, LockpickingSkillAdvance, SneakingSkillAdvance, AlchemySkillAdvance, SpeechcraftSkillAdvance, AlterationSkillAdvance, ConjurationSkillAdvance, DestructionSkillAdvance, IllusionSkillAdvance, RestorationSkillAdvance, EnchantingSkillAdvance, LeftWeaponSpeedMultiply, DragonSouls, CombatHealthRegenMultiply, OneHandedPowerModifier, TwoHandedPowerModifier, MarksmanPowerModifier, BlockPowerModifier, SmithingPowerModifier, HeavyArmorPowerModifier, LightArmorPowerModifier, PickpocketPowerModifier, LockpickingPowerModifier, SneakingPowerModifier, AlchemyPowerModifier, SpeechcraftPowerModifier, AlterationPowerModifier, ConjurationPowerModifier, DestructionPowerModifier, IllusionPowerModifier, RestorationPowerModifier, EnchantingPowerModifier, DragonRend, AttackDamageMult, HealRateMult, MagickaRateMult, StaminaRateMult, WerewolfPerks, VampirePerks, GrabActorOffset, Grabbed, ReflectDamage, None) | "MagicSkill": "Aggression"                       |
+| MenuDisplayObject       | MDOB           | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| MinimumSkillLevel       |                | MFF-- | Numeric value                                                                                                                                      | "MinimumSkillLevel": 7                           |
+| Name                    | FULL           | MFF-- | String value                                                                                                                                       | "Name": "Hello"                                  |
+| PerkToApply             |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| Projectile              |                | MFF-- | Form Key or Editor ID                                                                                                                              |                                                  |
+| ResistValue             |                | MF--- | Possible values (Aggression, Confidence, Energy, Morality, Mood, Assistance, OneHanded, TwoHanded, Archery, Block, Smithing, HeavyArmor, LightArmor, Pickpocket, Lockpicking, Sneak, Alchemy, Speech, Alteration, Conjuration, Destruction, Illusion, Restoration, Enchanting, Health, Magicka, Stamina, HealRate, MagickaRate, StaminaRate, SpeedMult, InventoryWeight, CarryWeight, CriticalChance, MeleeDamage, UnarmedDamage, Mass, VoicePoints, VoiceRate, DamageResist, PoisonResist, ResistFire, ResistShock, ResistFrost, ResistMagic, ResistDisease, Paralysis, Invisibility, NightEye, DetectLifeRange, WaterBreathing, WaterWalking, Fame, Infamy, JumpingBonus, WardPower, RightItemCharge, ArmorPerks, ShieldPerks, WardDeflection, Variable01, Variable02, Variable03, Variable04, Variable05, Variable06, Variable07, Variable08, Variable09, Variable10, BowSpeedBonus, FavorActive, FavorsPerDay, FavorsPerDayTimer, LeftItemCharge, AbsorbChance, Blindness, WeaponSpeedMult, ShoutRecoveryMult, BowStaggerBonus, Telekinesis, FavorPointsBonus, LastBribedIntimidated, LastFlattered, MovementNoiseMult, BypassVendorStolenCheck, BypassVendorKeywordCheck, WaitingForPlayer, OneHandedModifier, TwoHandedModifier, MarksmanModifier, BlockModifier, SmithingModifier, HeavyArmorModifier, LightArmorModifier, PickpocketModifier, LockpickingModifier, SneakingModifier, AlchemyModifier, SpeechcraftModifier, AlterationModifier, ConjurationModifier, DestructionModifier, IllusionModifier, RestorationModifier, EnchantingModifier, OneHandedSkillAdvance, TwoHandedSkillAdvance, MarksmanSkillAdvance, BlockSkillAdvance, SmithingSkillAdvance, HeavyArmorSkillAdvance, LightArmorSkillAdvance, PickpocketSkillAdvance, LockpickingSkillAdvance, SneakingSkillAdvance, AlchemySkillAdvance, SpeechcraftSkillAdvance, AlterationSkillAdvance, ConjurationSkillAdvance, DestructionSkillAdvance, IllusionSkillAdvance, RestorationSkillAdvance, EnchantingSkillAdvance, LeftWeaponSpeedMultiply, DragonSouls, CombatHealthRegenMultiply, OneHandedPowerModifier, TwoHandedPowerModifier, MarksmanPowerModifier, BlockPowerModifier, SmithingPowerModifier, HeavyArmorPowerModifier, LightArmorPowerModifier, PickpocketPowerModifier, LockpickingPowerModifier, SneakingPowerModifier, AlchemyPowerModifier, SpeechcraftPowerModifier, AlterationPowerModifier, ConjurationPowerModifier, DestructionPowerModifier, IllusionPowerModifier, RestorationPowerModifier, EnchantingPowerModifier, DragonRend, AttackDamageMult, HealRateMult, MagickaRateMult, StaminaRateMult, WerewolfPerks, VampirePerks, GrabActorOffset, Grabbed, ReflectDamage, None) | "ResistValue": "Aggression"                      |
+| ScriptEffectAIDelayTime |                | MFF-- | Decimal value                                                                                                                                      | "ScriptEffectAIDelayTime": 3.14                  |
+| ScriptEffectAIScore     |                | MFF-- | Decimal value                                                                                                                                      | "ScriptEffectAIScore": 3.14                      |
+| SecondActorValue        |                | MF--- | Possible values (Aggression, Confidence, Energy, Morality, Mood, Assistance, OneHanded, TwoHanded, Archery, Block, Smithing, HeavyArmor, LightArmor, Pickpocket, Lockpicking, Sneak, Alchemy, Speech, Alteration, Conjuration, Destruction, Illusion, Restoration, Enchanting, Health, Magicka, Stamina, HealRate, MagickaRate, StaminaRate, SpeedMult, InventoryWeight, CarryWeight, CriticalChance, MeleeDamage, UnarmedDamage, Mass, VoicePoints, VoiceRate, DamageResist, PoisonResist, ResistFire, ResistShock, ResistFrost, ResistMagic, ResistDisease, Paralysis, Invisibility, NightEye, DetectLifeRange, WaterBreathing, WaterWalking, Fame, Infamy, JumpingBonus, WardPower, RightItemCharge, ArmorPerks, ShieldPerks, WardDeflection, Variable01, Variable02, Variable03, Variable04, Variable05, Variable06, Variable07, Variable08, Variable09, Variable10, BowSpeedBonus, FavorActive, FavorsPerDay, FavorsPerDayTimer, LeftItemCharge, AbsorbChance, Blindness, WeaponSpeedMult, ShoutRecoveryMult, BowStaggerBonus, Telekinesis, FavorPointsBonus, LastBribedIntimidated, LastFlattered, MovementNoiseMult, BypassVendorStolenCheck, BypassVendorKeywordCheck, WaitingForPlayer, OneHandedModifier, TwoHandedModifier, MarksmanModifier, BlockModifier, SmithingModifier, HeavyArmorModifier, LightArmorModifier, PickpocketModifier, LockpickingModifier, SneakingModifier, AlchemyModifier, SpeechcraftModifier, AlterationModifier, ConjurationModifier, DestructionModifier, IllusionModifier, RestorationModifier, EnchantingModifier, OneHandedSkillAdvance, TwoHandedSkillAdvance, MarksmanSkillAdvance, BlockSkillAdvance, SmithingSkillAdvance, HeavyArmorSkillAdvance, LightArmorSkillAdvance, PickpocketSkillAdvance, LockpickingSkillAdvance, SneakingSkillAdvance, AlchemySkillAdvance, SpeechcraftSkillAdvance, AlterationSkillAdvance, ConjurationSkillAdvance, DestructionSkillAdvance, IllusionSkillAdvance, RestorationSkillAdvance, EnchantingSkillAdvance, LeftWeaponSpeedMultiply, DragonSouls, CombatHealthRegenMultiply, OneHandedPowerModifier, TwoHandedPowerModifier, MarksmanPowerModifier, BlockPowerModifier, SmithingPowerModifier, HeavyArmorPowerModifier, LightArmorPowerModifier, PickpocketPowerModifier, LockpickingPowerModifier, SneakingPowerModifier, AlchemyPowerModifier, SpeechcraftPowerModifier, AlterationPowerModifier, ConjurationPowerModifier, DestructionPowerModifier, IllusionPowerModifier, RestorationPowerModifier, EnchantingPowerModifier, DragonRend, AttackDamageMult, HealRateMult, MagickaRateMult, StaminaRateMult, WerewolfPerks, VampirePerks, GrabActorOffset, Grabbed, ReflectDamage, None) | "SecondActorValue": "Aggression"                 |
+| SecondActorValueWeight  |                | MFF-- | Decimal value                                                                                                                                      | "SecondActorValueWeight": 3.14                   |
+| SkillUsageMultiplier    |                | MFF-- | Decimal value                                                                                                                                      | "SkillUsageMultiplier": 3.14                     |
+| SkyrimMajorRecordFlags  |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)          | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| SpellmakingArea         |                | MFF-- | Numeric value                                                                                                                                      | "SpellmakingArea": 7                             |
+| SpellmakingCastingTime  |                | MFF-- | Decimal value                                                                                                                                      | "SpellmakingCastingTime": 3.14                   |
+| TaperCurve              |                | MFF-- | Decimal value                                                                                                                                      | "TaperCurve": 3.14                               |
+| TaperDuration           |                | MFF-- | Decimal value                                                                                                                                      | "TaperDuration": 3.14                            |
+| TaperWeight             |                | MFF-- | Decimal value                                                                                                                                      | "TaperWeight": 3.14                              |
+| TargetType              |                | MF--- | Possible values (Self, Touch, Aimed, TargetActor, TargetLocation)                                                                                  | "TargetType": "Self"                             |
+| Unknown1                |                | MFF-- | Numeric value                                                                                                                                      | "Unknown1": 7                                    |
 
 [⬅ Back to Types](Types.md)
 
 ## MATO - MaterialObject
 
-| Field           | Alt            | MFFSM | Value Type                                                                                                                                                                    | Example                       |
-| --------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| FalloffBias     |                | MFF-- | Decimal value                                                                                                                                                                 | "FalloffBias": 3.14           |
-| FalloffScale    |                | MFF-- | Decimal value                                                                                                                                                                 | "FalloffScale": 3.14          |
-| Flags           | DataFlags;FNAM | MF--- | Flags (SinglePass)                                                                                                                                                            | "Flags": "SinglePass"         |
-| HasSnow         |                | MFF-- | True / False                                                                                                                                                                  | "HasSnow": true               |
-| MaterialUvScale |                | MFF-- | Decimal value                                                                                                                                                                 | "MaterialUvScale": 3.14       |
-| NoiseUvScale    |                | MFF-- | Decimal value                                                                                                                                                                 | "NoiseUvScale": 3.14          |
-| NormalDampener  |                | MFF-- | Decimal value                                                                                                                                                                 | "NormalDampener": 3.14        |
-| SinglePassColor |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "SinglePassColor": [40,50,60] |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                          | Example                                          |
+| ---------------------- | -------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                                        | "EditorID": "Hello"                              |
+| FalloffBias            |                | MFF-- | Decimal value                                                                                                                                       | "FalloffBias": 3.14                              |
+| FalloffScale           |                | MFF-- | Decimal value                                                                                                                                       | "FalloffScale": 3.14                             |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (SinglePass)                                                                                                                                  | "Flags": "SinglePass"                            |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                                       | "FormVersion": 7                                 |
+| HasSnow                |                | MFF-- | True / False                                                                                                                                        | "HasSnow": true                                  |
+| MaterialUvScale        |                | MFF-- | Decimal value                                                                                                                                       | "MaterialUvScale": 3.14                          |
+| NoiseUvScale           |                | MFF-- | Decimal value                                                                                                                                       | "NoiseUvScale": 3.14                             |
+| NormalDampener         |                | MFF-- | Decimal value                                                                                                                                       | "NormalDampener": 3.14                           |
+| SinglePassColor        |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "SinglePassColor": [40,50,60]                    |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)           | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## MATT - MaterialType
 
-| Field              | Alt            | MFFSM | Value Type                                                                                                                                                  | Example                                      |
-| ------------------ | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| Buoyancy           |                | MFF-- | Decimal value                                                                                                                                               | "Buoyancy": 3.14                             |
-| Flags              | DataFlags;FNAM | MF--- | Flags (StairMaterial, ArrowsStick)                                                                                                                          | "Flags": [ "StairMaterial", "-ArrowsStick" ] |
-| HavokDisplayColor  |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "HavokDisplayColor": [40,50,60]              |
-| HavokImpactDataSet |                | MFF-- | Form Key or Editor ID                                                                                                                                       |                                              |
-| Name               | FULL           | MFF-- | String value                                                                                                                                                | "Name": "Hello"                              |
-| Parent             |                | MFF-- | Form Key or Editor ID                                                                                                                                       |                                              |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                          | Example                                          |
+| ---------------------- | -------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Buoyancy               | BNAM           | MFF-- | Decimal value                                                                                                                                       | "Buoyancy": 3.14                                 |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                                        | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (StairMaterial, ArrowsStick)                                                                                                                  | "Flags": [ "StairMaterial", "-ArrowsStick" ]     |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                                       | "FormVersion": 7                                 |
+| HavokDisplayColor      | CNAM           | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "HavokDisplayColor": [40,50,60]                  |
+| HavokImpactDataSet     | HNAM           | MFF-- | Form Key or Editor ID                                                                                                                               |                                                  |
+| Name                   | FULL           | MFF-- | String value                                                                                                                                        | "Name": "Hello"                                  |
+| Parent                 | PNAM           | MFF-- | Form Key or Editor ID                                                                                                                               |                                                  |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)           | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## MESG - Message
 
-| Field       | Alt            | MFFSM | Value Type                      | Example                                   |
-| ----------- | -------------- | ----- | ------------------------------- | ----------------------------------------- |
-| Description | DESC           | MFF-- | String value                    | "Description": "Hello"                    |
-| DisplayTime |                | MFF-- | Numeric value                   | "DisplayTime": 7                          |
-| Flags       | DataFlags;FNAM | MF--- | Flags (MessageBox, AutoDisplay) | "Flags": [ "MessageBox", "-AutoDisplay" ] |
-| Name        | FULL           | MFF-- | String value                    | "Name": "Hello"                           |
-| Quest       |                | MFF-- | Form Key or Editor ID           |                                           |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Description            | DESC           | MFF-- | String value                                                                                                                              | "Description": "Hello"                           |
+| DisplayTime            | TNAM           | MFF-- | Numeric value                                                                                                                             | "DisplayTime": 7                                 |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (MessageBox, AutoDisplay)                                                                                                           | "Flags": [ "MessageBox", "-AutoDisplay" ]        |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| INAM                   |                | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| Quest                  | QNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## MISC - MiscItem
 
-| Field        | Alt         | MFFSM | Value Type                                               | Example                       |
-| ------------ | ----------- | ----- | -------------------------------------------------------- | ----------------------------- |
-| Keywords     | KWDA        | MFFSM | Form Keys or Editor IDs                                  |                               |
-| MajorFlags   | RecordFlags | MF--- | Flags (NonPlayable)                                      | "MajorFlags": "NonPlayable"   |
-| Name         | FULL        | MFF-- | String value                                             | "Name": "Hello"               |
-| ObjectBounds | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9] |
-| PickUpSound  | YNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| PutDownSound | ZNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| Value        |             | MFF-- | Numeric value                                            | "Value": 7                    |
-| Weight       |             | MFF-- | Decimal value                                            | "Weight": 3.14                |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Keywords               | KWDA        | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| MajorFlags             | RecordFlags | MF--- | Flags (NonPlayable)                                                                                                                       | "MajorFlags": "NonPlayable"                      |
+| Name                   | FULL        | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| ObjectBounds           | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| PickUpSound            | YNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PutDownSound           | ZNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Value                  |             | MFF-- | Numeric value                                                                                                                             | "Value": 7                                       |
+| Weight                 |             | MFF-- | Decimal value                                                                                                                             | "Weight": 3.14                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## MSTT - MoveableStatic
 
-| Field        | Alt            | MFFSM | Value Type                                                                                                                                     | Example                                                         |
-| ------------ | -------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| Flags        | DataFlags;FNAM | MF--- | Flags (OnLocalMap)                                                                                                                             | "Flags": "OnLocalMap"                                           |
-| LoopingSound |                | MFF-- | Form Key or Editor ID                                                                                                                          |                                                                 |
-| MajorFlags   | RecordFlags    | MF--- | Flags (MustUpdateAnims, HiddenFromLocalMap, HasDistantLOD, RandomAnimStart, HasCurrents, Obstacle, NavMeshGenerationFilter, NavMeshGenerationBoundingBox, NavMeshGenerationGround) | "MajorFlags": [ "MustUpdateAnims", "-NavMeshGenerationGround" ] |
-| Name         | FULL           | MFF-- | String value                                                                                                                                   | "Name": "Hello"                                                 |
-| ObjectBounds | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                       | "ObjectBounds": [6,6,6,9,9,9]                                   |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                           | Example                                                         |
+| ---------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                         | "EditorID": "Hello"                                             |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (OnLocalMap)                                                                                                                   | "Flags": "OnLocalMap"                                           |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                        | "FormVersion": 7                                                |
+| LoopingSound           | SNAM           | MFF-- | Form Key or Editor ID                                                                                                                |                                                                 |
+| MajorFlags             | RecordFlags    | MF--- | Flags (MustUpdateAnims, HiddenFromLocalMap, HasDistantLOD, RandomAnimStart, HasCurrents, Obstacle, NavMeshGenerationFilter, NavMeshGenerationBoundingBox, NavMeshGenerationGround) | "MajorFlags": [ "MustUpdateAnims", "-NavMeshGenerationGround" ] |
+| Name                   | FULL           | MFF-- | String value                                                                                                                         | "Name": "Hello"                                                 |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                             | "ObjectBounds": [6,6,6,9,9,9]                                   |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                |
 
 [⬅ Back to Types](Types.md)
 
 ## MOVT - MovementType
 
-| Field                | Alt  | MFFSM | Value Type     | Example                       |
-| -------------------- | ---- | ----- | -------------- | ----------------------------- |
-| BackRun              |      | MFF-- | Decimal value  | "BackRun": 3.14               |
-| BackWalk             |      | MFF-- | Decimal value  | "BackWalk": 3.14              |
-| ForwardRun           |      | MFF-- | Decimal value  | "ForwardRun": 3.14            |
-| ForwardWalk          |      | MFF-- | Decimal value  | "ForwardWalk": 3.14           |
-| LeftRun              |      | MFF-- | Decimal value  | "LeftRun": 3.14               |
-| LeftWalk             |      | MFF-- | Decimal value  | "LeftWalk": 3.14              |
-| Name                 | FULL | MFF-- | String value   | "Name": "Hello"               |
-| RightRun             |      | MFF-- | Decimal value  | "RightRun": 3.14              |
-| RightWalk            |      | MFF-- | Decimal value  | "RightWalk": 3.14             |
-| RotateInPlaceRun     |      | MFF-- | Decimal value  | "RotateInPlaceRun": 3.14      |
-| RotateInPlaceWalk    |      | MFF-- | Decimal value  | "RotateInPlaceWalk": 3.14     |
-| RotateWhileMovingRun |      | MFF-- | Decimal value  | "RotateWhileMovingRun": 3.14  |
-| SPEDDataTypeState    |      | MF--- | Flags (Break0) | "SPEDDataTypeState": "Break0" |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| BackRun                |      | MFF-- | Decimal value                                                                                                                             | "BackRun": 3.14                                  |
+| BackWalk               |      | MFF-- | Decimal value                                                                                                                             | "BackWalk": 3.14                                 |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| ForwardRun             |      | MFF-- | Decimal value                                                                                                                             | "ForwardRun": 3.14                               |
+| ForwardWalk            |      | MFF-- | Decimal value                                                                                                                             | "ForwardWalk": 3.14                              |
+| LeftRun                |      | MFF-- | Decimal value                                                                                                                             | "LeftRun": 3.14                                  |
+| LeftWalk               |      | MFF-- | Decimal value                                                                                                                             | "LeftWalk": 3.14                                 |
+| Name                   | FULL | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| RightRun               |      | MFF-- | Decimal value                                                                                                                             | "RightRun": 3.14                                 |
+| RightWalk              |      | MFF-- | Decimal value                                                                                                                             | "RightWalk": 3.14                                |
+| RotateInPlaceRun       |      | MFF-- | Decimal value                                                                                                                             | "RotateInPlaceRun": 3.14                         |
+| RotateInPlaceWalk      |      | MFF-- | Decimal value                                                                                                                             | "RotateInPlaceWalk": 3.14                        |
+| RotateWhileMovingRun   |      | MFF-- | Decimal value                                                                                                                             | "RotateWhileMovingRun": 3.14                     |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| SPEDDataTypeState      |      | MF--- | Flags (Break0)                                                                                                                            | "SPEDDataTypeState": "Break0"                    |
 
 [⬅ Back to Types](Types.md)
 
 ## MUST - MusicTrack
 
-| Field    | Alt | MFFSM | Value Type                                          | Example           |
-| -------- | --- | ----- | --------------------------------------------------- | ----------------- |
-| Duration |     | MFF-- | Decimal value                                       | "Duration": 3.14  |
-| FadeOut  |     | MFF-- | Decimal value                                       | "FadeOut": 3.14   |
-| Tracks   |     | MFFSM | Form Keys or Editor IDs                             |                   |
-| Type     |     | MF--- | Possible values (Palette, SingleTrack, SilentTrack) | "Type": "Palette" |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Duration               | FLTV | MFF-- | Decimal value                                                                                                                             | "Duration": 3.14                                 |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FadeOut                | DNAM | MFF-- | Decimal value                                                                                                                             | "FadeOut": 3.14                                  |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Tracks                 | SNAM | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| Type                   | CNAM | MF--- | Possible values (Palette, SingleTrack, SilentTrack)                                                                                       | "Type": "Palette"                                |
 
 [⬅ Back to Types](Types.md)
 
 ## MUSC - MusicType
 
-| Field        | Alt            | MFFSM | Value Type                                                                                                    | Example                                           |
-| ------------ | -------------- | ----- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| FadeDuration |                | MFF-- | Decimal value                                                                                                 | "FadeDuration": 3.14                              |
-| Flags        | DataFlags;FNAM | MF--- | Flags (PlaysOneSelection, AbruptTransition, CycleTracks, MaintainTrackOrder, DucksCurrentTrack, DoesNotQueue) | "Flags": [ "PlaysOneSelection", "-DoesNotQueue" ] |
-| Tracks       |                | MFFSM | Form Keys or Editor IDs                                                                                       |                                                   |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                           |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                               |
+| FadeDuration           | WNAM           | MFF-- | Decimal value                                                                                                                             | "FadeDuration": 3.14                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (PlaysOneSelection, AbruptTransition, CycleTracks, MaintainTrackOrder, DucksCurrentTrack, DoesNotQueue)                             | "Flags": [ "PlaysOneSelection", "-DoesNotQueue" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                  |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]  |
+| Tracks                 | TNAM           | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                   |
 
 [⬅ Back to Types](Types.md)
 
@@ -1122,8 +1401,10 @@ This just details where the field can currently be used.
 | DeathItem                          | INAM        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
 | DefaultOutfit                      | DOFT        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
 | DefaultPackageList                 | DPLT        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
-| Factions                           |             | MFFSM | JSON objects containing faction Form Key/Editor ID and Rank                                                                       | "Factions": { "Faction": "021FED:Skyrim.esm", "Rank": 0 } |
+| EditorID                           | EDID        | MFF-- | String value                                                                                                                      | "EditorID": "Hello"                                       |
+| Factions                           | SNAM        | MFFSM | JSON objects containing faction Form Key/Editor ID and Rank                                                                       | "Factions": { "Faction": "021FED:Skyrim.esm", "Rank": 0 } |
 | FarAwayModel                       | ANAM        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
+| FormVersion                        |             | MFF-- | Numeric value                                                                                                                     | "FormVersion": 7                                          |
 | GiftFilter                         | GNAM        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
 | GuardWarnOverridePackageList       | GWOR        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
 | HairColor                          | HCLF        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
@@ -1141,12 +1422,13 @@ This just details where the field can currently be used.
 | PlayerSkills                       | DNAM        | -FF-- | JSON object containing the values under PlayerSkills you want to set                                                              | See ../Examples/NPC Player Skills.json                    |
 | Race                               | RNAM        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
 | ShortName                          | ONAM        | MFF-- | String value                                                                                                                      | "ShortName": "Hello"                                      |
+| SkyrimMajorRecordFlags             |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]          |
 | SleepingOutfit                     | SOFT        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
 | Sound                              |             | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
 | SoundLevel                         | NAM8        | MF--- | Possible values (Loud, Normal, Silent, VeryLoud)                                                                                  | "SoundLevel": "Loud"                                      |
 | SpectatorOverridePackageList       | SPOR        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
 | Template                           | TPLT        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
-| TextureLighting                    |             | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "TextureLighting": [40,50,60]                             |
+| TextureLighting                    | QNAM        | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "TextureLighting": [40,50,60]                             |
 | Voice                              | VTCK        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
 | Weight                             | NAM7        | MFF-- | Decimal value                                                                                                                     | "Weight": 3.14                                            |
 | WornArmor                          | WNAM        | MFF-- | Form Key or Editor ID                                                                                                             |                                                           |
@@ -1155,29 +1437,35 @@ This just details where the field can currently be used.
 
 ## ENCH - ObjectEffect
 
-| Field             | Alt            | MFFSM | Value Type                                                        | Example                                                                                |
-| ----------------- | -------------- | ----- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| BaseEnchantment   |                | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| CastType          |                | MF--- | Possible values (ConstantEffect, FireAndForget, Concentration)    | "CastType": "ConstantEffect"                                                           |
-| ChargeTime        |                | MFF-- | Decimal value                                                     | "ChargeTime": 3.14                                                                     |
-| Effects           |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
-| EnchantmentAmount | EAMT           | MFF-- | Numeric value                                                     | "EnchantmentAmount": 7                                                                 |
-| EnchantmentCost   |                | MFF-- | Numeric value                                                     | "EnchantmentCost": 7                                                                   |
-| EnchantType       |                | MF--- | Possible values (Enchantment, StaffEnchantment)                   | "EnchantType": "Enchantment"                                                           |
-| ENITDataTypeState |                | MF--- | Flags (Break0)                                                    | "ENITDataTypeState": "Break0"                                                          |
-| Flags             | DataFlags;FNAM | MF--- | Flags (NoAutoCalc, ExtendDurationOnRecast)                        | "Flags": [ "NoAutoCalc", "-ExtendDurationOnRecast" ]                                   |
-| Name              | FULL           | MFF-- | String value                                                      | "Name": "Hello"                                                                        |
-| ObjectBounds      | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]          | "ObjectBounds": [6,6,6,9,9,9]                                                          |
-| TargetType        |                | MF--- | Possible values (Self, Touch, Aimed, TargetActor, TargetLocation) | "TargetType": "Self"                                                                   |
-| WornRestrictions  |                | MFF-- | Form Key or Editor ID                                             |                                                                                        |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                    | Example                                                                                |
+| ---------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| BaseEnchantment        |                | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| CastType               |                | MF--- | Possible values (ConstantEffect, FireAndForget, Concentration)                                                | "CastType": "ConstantEffect"                                                           |
+| ChargeTime             |                | MFF-- | Decimal value                                                                                                 | "ChargeTime": 3.14                                                                     |
+| EditorID               | EDID           | MFF-- | String value                                                                                                  | "EditorID": "Hello"                                                                    |
+| Effects                |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data                                             | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
+| EnchantmentAmount      | EAMT           | MFF-- | Numeric value                                                                                                 | "EnchantmentAmount": 7                                                                 |
+| EnchantmentCost        |                | MFF-- | Numeric value                                                                                                 | "EnchantmentCost": 7                                                                   |
+| EnchantType            |                | MF--- | Possible values (Enchantment, StaffEnchantment)                                                               | "EnchantType": "Enchantment"                                                           |
+| ENITDataTypeState      |                | MF--- | Flags (Break0)                                                                                                | "ENITDataTypeState": "Break0"                                                          |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (NoAutoCalc, ExtendDurationOnRecast)                                                                    | "Flags": [ "NoAutoCalc", "-ExtendDurationOnRecast" ]                                   |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                 | "FormVersion": 7                                                                       |
+| Name                   | FULL           | MFF-- | String value                                                                                                  | "Name": "Hello"                                                                        |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                      | "ObjectBounds": [6,6,6,9,9,9]                                                          |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                                       |
+| TargetType             |                | MF--- | Possible values (Self, Touch, Aimed, TargetActor, TargetLocation)                                             | "TargetType": "Self"                                                                   |
+| WornRestrictions       |                | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
 
 [⬅ Back to Types](Types.md)
 
 ## OTFT - Outfit
 
-| Field | Alt  | MFFSM | Value Type              | Example |
-| ----- | ---- | ----- | ----------------------- | ------- |
-| Items | Item | MFFSM | Form Keys or Editor IDs |         |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Items                  | Item | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
@@ -1185,12 +1473,14 @@ This just details where the field can currently be used.
 
 | Field                     | Alt            | MFFSM | Value Type                                                                                                                            | Example                                                     |
 | ------------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| CombatStyle               |                | MFF-- | Form Key or Editor ID                                                                                                                 |                                                             |
+| CombatStyle               | CNAM           | MFF-- | Form Key or Editor ID                                                                                                                 |                                                             |
 | DataInputVersion          |                | MFF-- | Numeric value                                                                                                                         | "DataInputVersion": 7                                       |
+| EditorID                  | EDID           | MFF-- | String value                                                                                                                          | "EditorID": "Hello"                                         |
 | Flags                     | DataFlags;FNAM | MF--- | Flags (OffersServices, MustComplete, MaintainSpeedAtGoal, UnlockDoorsAtPackageStart, UnlockDoorsAtPackageEnd, ContinueIfPcNear, OncePerDay, PreferredSpeed, AlwaysSneak, AllowSwimming, IgnoreCombat, WeaponsUnequipped, WeaponDrawn, WearSleepOutfit, NoCombatAlert) | "Flags": [ "OffersServices", "-NoCombatAlert" ]             |
+| FormVersion               |                | MFF-- | Numeric value                                                                                                                         | "FormVersion": 7                                            |
 | InterruptOverride         |                | MF--- | Possible values (None, Spectator, ObserveDead, GuardWarn, Combat)                                                                     | "InterruptOverride": "None"                                 |
 | InteruptFlags             |                | MF--- | Flags (HellosToPlayer, RandomConversations, ObserveCombatBehavior, GreetCorpseBehavior, ReactionToPlayerActions, FriendlyFireComments, AggroRadiusBehavior, AllowIdleChatter, WorldInteractions) | "InteruptFlags": [ "HellosToPlayer", "-WorldInteractions" ] |
-| OwnerQuest                |                | MFF-- | Form Key or Editor ID                                                                                                                 |                                                             |
+| OwnerQuest                | QNAM           | MFF-- | Form Key or Editor ID                                                                                                                 |                                                             |
 | PackageTemplate           |                | MFF-- | Form Key or Editor ID                                                                                                                 |                                                             |
 | PreferredSpeed            |                | MF--- | Possible values (Walk, Jog, Run, FastWalk)                                                                                            | "PreferredSpeed": "Walk"                                    |
 | ScheduleDate              |                | MFF-- | Numeric value                                                                                                                         | "ScheduleDate": 7                                           |
@@ -1199,484 +1489,570 @@ This just details where the field can currently be used.
 | ScheduleHour              |                | MFF-- | Numeric value                                                                                                                         | "ScheduleHour": 7                                           |
 | ScheduleMinute            |                | MFF-- | Numeric value                                                                                                                         | "ScheduleMinute": 7                                         |
 | ScheduleMonth             |                | MFF-- | Numeric value                                                                                                                         | "ScheduleMonth": 7                                          |
+| SkyrimMajorRecordFlags    |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]            |
 | Type                      |                | MF--- | Possible values (Package, PackageTemplate)                                                                                            | "Type": "Package"                                           |
+| XnamMarker                | XNAM           | -FF-- | Memory slice in form of array of bytes                                                                                                | [0x1A,0x00,0x3F]                                            |
 
 [⬅ Back to Types](Types.md)
 
 ## PERK - Perk
 
-| Field       | Alt         | MFFSM | Value Type                                                        | Example                                                                                |
-| ----------- | ----------- | ----- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Description | DESC        | MFF-- | String value                                                      | "Description": "Hello"                                                                 |
-| Effects     |             | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
-| Hidden      |             | MFF-- | True / False                                                      | "Hidden": true                                                                         |
-| Level       |             | MFF-- | Numeric value                                                     | "Level": 7                                                                             |
-| MajorFlags  | RecordFlags | MF--- | Flags (NonPlayable)                                               | "MajorFlags": "NonPlayable"                                                            |
-| Name        | FULL        | MFF-- | String value                                                      | "Name": "Hello"                                                                        |
-| NextPerk    |             | MFF-- | Form Key or Editor ID                                             |                                                                                        |
-| NumRanks    |             | MFF-- | Numeric value                                                     | "NumRanks": 7                                                                          |
-| Playable    |             | MFF-- | True / False                                                      | "Playable": true                                                                       |
-| Trait       |             | MFF-- | True / False                                                      | "Trait": true                                                                          |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                       | Example                                                                                |
+| ---------------------- | ----------- | ----- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Description            | DESC        | MFF-- | String value                                                                                                     | "Description": "Hello"                                                                 |
+| EditorID               | EDID        | MFF-- | String value                                                                                                     | "EditorID": "Hello"                                                                    |
+| Effects                |             | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data                                                | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                    | "FormVersion": 7                                                                       |
+| Hidden                 |             | MFF-- | True / False                                                                                                     | "Hidden": true                                                                         |
+| Level                  |             | MFF-- | Numeric value                                                                                                    | "Level": 7                                                                             |
+| MajorFlags             | RecordFlags | MF--- | Flags (NonPlayable)                                                                                              | "MajorFlags": "NonPlayable"                                                            |
+| Name                   | FULL        | MFF-- | String value                                                                                                     | "Name": "Hello"                                                                        |
+| NextPerk               | NNAM        | MFF-- | Form Key or Editor ID                                                                                            |                                                                                        |
+| NumRanks               |             | MFF-- | Numeric value                                                                                                    | "NumRanks": 7                                                                          |
+| Playable               |             | MFF-- | True / False                                                                                                     | "Playable": true                                                                       |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                                       |
+| Trait                  |             | MFF-- | True / False                                                                                                     | "Trait": true                                                                          |
 
 [⬅ Back to Types](Types.md)
 
 ## PROJ - Projectile
 
-| Field                        | Alt            | MFFSM | Value Type                                                                                                                                                | Example                              |
-| ---------------------------- | -------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| CollisionLayer               |                | MFF-- | Form Key or Editor ID                                                                                                                                     |                                      |
-| CollisionRadius              |                | MFF-- | Decimal value                                                                                                                                             | "CollisionRadius": 3.14              |
-| ConeSpread                   |                | MFF-- | Decimal value                                                                                                                                             | "ConeSpread": 3.14                   |
-| CountdownSound               |                | MFF-- | Form Key or Editor ID                                                                                                                                     |                                      |
-| DecalData                    |                | MFF-- | Form Key or Editor ID                                                                                                                                     |                                      |
-| DefaultWeaponSource          |                | MFF-- | Form Key or Editor ID                                                                                                                                     |                                      |
-| DisaleSound                  |                | MFF-- | Form Key or Editor ID                                                                                                                                     |                                      |
-| Explosion                    |                | MFF-- | Form Key or Editor ID                                                                                                                                     |                                      |
-| ExplosionAltTriggerProximity |                | MFF-- | Decimal value                                                                                                                                             | "ExplosionAltTriggerProximity": 3.14 |
-| ExplosionAltTriggerTimer     |                | MFF-- | Decimal value                                                                                                                                             | "ExplosionAltTriggerTimer": 3.14     |
-| FadeDuration                 |                | MFF-- | Decimal value                                                                                                                                             | "FadeDuration": 3.14                 |
-| Flags                        | DataFlags;FNAM | MF--- | Flags (Hitscan, Explosion, AltTrigger, MuzzleFlash, CanBeDisabled, CanBePickedUp, Supersonic, PinsLimbs, PassThroughSmallTransparent, DisableCombatAimCorrection, Rotation) | "Flags": [ "Hitscan", "-Rotation" ]  |
-| Gravity                      |                | MFF-- | Decimal value                                                                                                                                             | "Gravity": 3.14                      |
-| ImpactForce                  |                | MFF-- | Decimal value                                                                                                                                             | "ImpactForce": 3.14                  |
-| Lifetime                     |                | MFF-- | Decimal value                                                                                                                                             | "Lifetime": 3.14                     |
-| Light                        |                | MFF-- | Form Key or Editor ID                                                                                                                                     |                                      |
-| MuzzleFlash                  |                | MFF-- | Form Key or Editor ID                                                                                                                                     |                                      |
-| MuzzleFlashDuration          |                | MFF-- | Decimal value                                                                                                                                             | "MuzzleFlashDuration": 3.14          |
-| Name                         | FULL           | MFF-- | String value                                                                                                                                              | "Name": "Hello"                      |
-| ObjectBounds                 | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                                  | "ObjectBounds": [6,6,6,9,9,9]        |
-| Range                        |                | MFF-- | Decimal value                                                                                                                                             | "Range": 3.14                        |
-| RelaunchInterval             |                | MFF-- | Decimal value                                                                                                                                             | "RelaunchInterval": 3.14             |
-| Sound                        |                | MFF-- | Form Key or Editor ID                                                                                                                                     |                                      |
-| SoundLevel                   |                | MFF-- | Numeric value                                                                                                                                             | "SoundLevel": 7                      |
-| Speed                        |                | MFF-- | Decimal value                                                                                                                                             | "Speed": 3.14                        |
-| TracerChance                 |                | MFF-- | Decimal value                                                                                                                                             | "TracerChance": 3.14                 |
-| Type                         |                | MF--- | Possible values (Missile, Lobber, Beam, Flame, Cone, Barrier, Arrow)                                                                                      | "Type": "Missile"                    |
+| Field                        | Alt            | MFFSM | Value Type                                                                                                                                    | Example                                          |
+| ---------------------------- | -------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| CollisionLayer               |                | MFF-- | Form Key or Editor ID                                                                                                                         |                                                  |
+| CollisionRadius              |                | MFF-- | Decimal value                                                                                                                                 | "CollisionRadius": 3.14                          |
+| ConeSpread                   |                | MFF-- | Decimal value                                                                                                                                 | "ConeSpread": 3.14                               |
+| CountdownSound               |                | MFF-- | Form Key or Editor ID                                                                                                                         |                                                  |
+| DecalData                    |                | MFF-- | Form Key or Editor ID                                                                                                                         |                                                  |
+| DefaultWeaponSource          |                | MFF-- | Form Key or Editor ID                                                                                                                         |                                                  |
+| DisaleSound                  |                | MFF-- | Form Key or Editor ID                                                                                                                         |                                                  |
+| EditorID                     | EDID           | MFF-- | String value                                                                                                                                  | "EditorID": "Hello"                              |
+| Explosion                    |                | MFF-- | Form Key or Editor ID                                                                                                                         |                                                  |
+| ExplosionAltTriggerProximity |                | MFF-- | Decimal value                                                                                                                                 | "ExplosionAltTriggerProximity": 3.14             |
+| ExplosionAltTriggerTimer     |                | MFF-- | Decimal value                                                                                                                                 | "ExplosionAltTriggerTimer": 3.14                 |
+| FadeDuration                 |                | MFF-- | Decimal value                                                                                                                                 | "FadeDuration": 3.14                             |
+| Flags                        | DataFlags;FNAM | MF--- | Flags (Hitscan, Explosion, AltTrigger, MuzzleFlash, CanBeDisabled, CanBePickedUp, Supersonic, PinsLimbs, PassThroughSmallTransparent, DisableCombatAimCorrection, Rotation) | "Flags": [ "Hitscan", "-Rotation" ]              |
+| FormVersion                  |                | MFF-- | Numeric value                                                                                                                                 | "FormVersion": 7                                 |
+| Gravity                      |                | MFF-- | Decimal value                                                                                                                                 | "Gravity": 3.14                                  |
+| ImpactForce                  |                | MFF-- | Decimal value                                                                                                                                 | "ImpactForce": 3.14                              |
+| Lifetime                     |                | MFF-- | Decimal value                                                                                                                                 | "Lifetime": 3.14                                 |
+| Light                        |                | MFF-- | Form Key or Editor ID                                                                                                                         |                                                  |
+| MuzzleFlash                  |                | MFF-- | Form Key or Editor ID                                                                                                                         |                                                  |
+| MuzzleFlashDuration          |                | MFF-- | Decimal value                                                                                                                                 | "MuzzleFlashDuration": 3.14                      |
+| Name                         | FULL           | MFF-- | String value                                                                                                                                  | "Name": "Hello"                                  |
+| ObjectBounds                 | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                      | "ObjectBounds": [6,6,6,9,9,9]                    |
+| Range                        |                | MFF-- | Decimal value                                                                                                                                 | "Range": 3.14                                    |
+| RelaunchInterval             |                | MFF-- | Decimal value                                                                                                                                 | "RelaunchInterval": 3.14                         |
+| SkyrimMajorRecordFlags       |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)     | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Sound                        |                | MFF-- | Form Key or Editor ID                                                                                                                         |                                                  |
+| SoundLevel                   | VNAM           | MFF-- | Numeric value                                                                                                                                 | "SoundLevel": 7                                  |
+| Speed                        |                | MFF-- | Decimal value                                                                                                                                 | "Speed": 3.14                                    |
+| TextureFilesHashes           |                | -FF-- | Memory slice in form of array of bytes                                                                                                        | [0x1A,0x00,0x3F]                                 |
+| TracerChance                 |                | MFF-- | Decimal value                                                                                                                                 | "TracerChance": 3.14                             |
+| Type                         |                | MF--- | Possible values (Missile, Lobber, Beam, Flame, Cone, Barrier, Arrow)                                                                          | "Type": "Missile"                                |
 
 [⬅ Back to Types](Types.md)
 
 ## QUST - Quest
 
-| Field              | Alt            | MFFSM | Value Type                                                                                                                                    | Example                                                    |
-| ------------------ | -------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| Description        | DESC           | MFF-- | String value                                                                                                                                  | "Description": "Hello"                                     |
-| Filter             |                | MFF-- | String value                                                                                                                                  | "Filter": "Hello"                                          |
-| Flags              | DataFlags;FNAM | MF--- | Flags (StartGameEnabled, AllowRepeatedStages, RunOnce, ExcludeFromDialogExport, WarnOnAliasFillFailure)                                       | "Flags": [ "StartGameEnabled", "-WarnOnAliasFillFailure" ] |
-| Name               | FULL           | MFF-- | String value                                                                                                                                  | "Name": "Hello"                                            |
-| NextAliasID        |                | MFF-- | Numeric value                                                                                                                                 | "NextAliasID": 7                                           |
-| Priority           |                | MFF-- | Numeric value                                                                                                                                 | "Priority": 7                                              |
-| QuestFormVersion   |                | MFF-- | Numeric value                                                                                                                                 | "QuestFormVersion": 7                                      |
-| TextDisplayGlobals |                | MFFSM | Form Keys or Editor IDs                                                                                                                       |                                                            |
-| Type               |                | MF--- | Possible values (None, MainQuest, MageGuild, ThievesGuild, DarkBrotherhood, CompanionQuests, Misc, Daedric, SideQuest, CivilWar, Vampire, Dragonborn) | "Type": "None"                                             |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                                    |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Description            | DESC           | MFF-- | String value                                                                                                                              | "Description": "Hello"                                     |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                        |
+| Filter                 | FLTR           | MFF-- | String value                                                                                                                              | "Filter": "Hello"                                          |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (StartGameEnabled, AllowRepeatedStages, RunOnce, ExcludeFromDialogExport, WarnOnAliasFillFailure)                                   | "Flags": [ "StartGameEnabled", "-WarnOnAliasFillFailure" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                           |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                            |
+| NextAliasID            | ANAM           | MFF-- | Numeric value                                                                                                                             | "NextAliasID": 7                                           |
+| Priority               |                | MFF-- | Numeric value                                                                                                                             | "Priority": 7                                              |
+| QuestFormVersion       |                | MFF-- | Numeric value                                                                                                                             | "QuestFormVersion": 7                                      |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]           |
+| TextDisplayGlobals     | QTGL           | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                            |
+| Type                   |                | MF--- | Possible values (None, MainQuest, MageGuild, ThievesGuild, DarkBrotherhood, CompanionQuests, Misc, Daedric, SideQuest, CivilWar, Vampire, Dragonborn) | "Type": "None"                                             |
 
 [⬅ Back to Types](Types.md)
 
 ## RACE - Race
 
-| Field                     | Alt            | MFFSM | Value Type                                                                                                                                        | Example                                         |
-| ------------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| AccelerationRate          |                | MFF-- | Decimal value                                                                                                                                     | "AccelerationRate": 3.14                        |
-| ActorEffect               |                | MFFSM | Form Keys or Editor IDs                                                                                                                           |                                                 |
-| AimAngleTolerance         |                | MFF-- | Decimal value                                                                                                                                     | "AimAngleTolerance": 3.14                       |
-| AngularAccelerationRate   |                | MFF-- | Decimal value                                                                                                                                     | "AngularAccelerationRate": 3.14                 |
-| AngularTolerance          |                | MFF-- | Decimal value                                                                                                                                     | "AngularTolerance": 3.14                        |
-| ArmorRace                 |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| AttackRace                |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| BaseCarryWeight           |                | MFF-- | Decimal value                                                                                                                                     | "BaseCarryWeight": 3.14                         |
-| BaseMass                  |                | MFF-- | Decimal value                                                                                                                                     | "BaseMass": 3.14                                |
-| BaseMovementDefaultFly    |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| BaseMovementDefaultRun    |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| BaseMovementDefaultSneak  |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| BaseMovementDefaultSprint |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| BaseMovementDefaultSwim   |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| BaseMovementDefaultWalk   |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| BodyBipedObject           |                | MF--- | Possible values (Head, Hair, Body, Hands, Forearms, Amulet, Ring, Feet, Calves, Shield, Tail, LongHair, Circlet, Ears, DecapitateHead, Decapitate, FX01, None) | "BodyBipedObject": "Head"                       |
-| BodyPartData              |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| CloseLootSound            |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| DecapitationFX            |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| DecelerationRate          |                | MFF-- | Decimal value                                                                                                                                     | "DecelerationRate": 3.14                        |
-| Description               | DESC           | MFF-- | String value                                                                                                                                      | "Description": "Hello"                          |
-| EquipmentFlags            |                | MF--- | Flags (HandToHand, OneHandSword, OneHandDagger, OneHandAxe, OneHandMace, TwoHandSword, TwoHandAxe, Bow, Staff, Spell, Shield, Torch, Crossbow)    | "EquipmentFlags": [ "HandToHand", "-Crossbow" ] |
-| EquipmentSlots            |                | MFFSM | Form Keys or Editor IDs                                                                                                                           |                                                 |
-| ExportingExtraNam2        |                | MFF-- | True / False                                                                                                                                      | "ExportingExtraNam2": true                      |
-| Eyes                      |                | MFFSM | Form Keys or Editor IDs                                                                                                                           |                                                 |
-| FacegenFaceClamp          |                | MFF-- | Decimal value                                                                                                                                     | "FacegenFaceClamp": 3.14                        |
-| FacegenMainClamp          |                | MFF-- | Decimal value                                                                                                                                     | "FacegenMainClamp": 3.14                        |
-| Flags                     | DataFlags;FNAM | MF--- | Flags (Playable, FaceGenHead, Child, TiltFrontBack, TiltLeftRight, NoShadow, Swims, Flies, Walks, Immobile, NotPunishable, NoCombatInWater, NoRotatingToHeadTrack, DontShowBloodSpray, DontShowBloodDecal, UsesHeadTrackAnims, SpellsAlignWithMagicNode, UseWorldRaycastsForFootIK, AllowRagdollCollision, RegenHpInCombat, CantOpenDoors, AllowPcDialog, NoKnockdowns, AllowPickpocket, AlwaysUseProxyController, DontShowWeaponBlood, OverlayHeadPartList, OverrideHeadPartList, CanPickupItems, AllowMultipleMembraneShaders, CanDualWield, AvoidsRoads, UseAdvancedAvoidance, NonHostile, AllowMountedCombat) | "Flags": [ "Playable", "-AllowMountedCombat" ]  |
-| FlightRadius              |                | MFF-- | Decimal value                                                                                                                                     | "FlightRadius": 3.14                            |
-| HairBipedObject           |                | MF--- | Possible values (Head, Hair, Body, Hands, Forearms, Amulet, Ring, Feet, Calves, Shield, Tail, LongHair, Circlet, Ears, DecapitateHead, Decapitate, FX01, None) | "HairBipedObject": "Head"                       |
-| Hairs                     |                | MFFSM | Form Keys or Editor IDs                                                                                                                           |                                                 |
-| HeadBipedObject           |                | MF--- | Possible values (Head, Hair, Body, Hands, Forearms, Amulet, Ring, Feet, Calves, Shield, Tail, LongHair, Circlet, Ears, DecapitateHead, Decapitate, FX01, None) | "HeadBipedObject": "Head"                       |
-| ImpactDataSet             |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| InjuredHealthPercent      |                | MFF-- | Decimal value                                                                                                                                     | "InjuredHealthPercent": 3.14                    |
-| Keywords                  | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                                                           |                                                 |
-| MajorFlags                | RecordFlags    | MF--- | Flags (Critter)                                                                                                                                   | "MajorFlags": "Critter"                         |
-| MaterialType              |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| MorphRace                 |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| Name                      | FULL           | MFF-- | String value                                                                                                                                      | "Name": "Hello"                                 |
-| NumberOfTintsInList       |                | MFF-- | Numeric value                                                                                                                                     | "NumberOfTintsInList": 7                        |
-| OpenLootSound             |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| ShieldBipedObject         |                | MF--- | Possible values (Head, Hair, Body, Hands, Forearms, Amulet, Ring, Feet, Calves, Shield, Tail, LongHair, Circlet, Ears, DecapitateHead, Decapitate, FX01, None) | "ShieldBipedObject": "Head"                     |
-| Size                      |                | MF--- | Possible values (Small, Medium, Large, ExtraLarge)                                                                                                | "Size": "Small"                                 |
-| Skin                      |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| UnarmedDamage             |                | MFF-- | Decimal value                                                                                                                                     | "UnarmedDamage": 3.14                           |
-| UnarmedEquipSlot          |                | MFF-- | Form Key or Editor ID                                                                                                                             |                                                 |
-| UnarmedReach              |                | MFF-- | Decimal value                                                                                                                                     | "UnarmedReach": 3.14                            |
-| Weight                    |                | MFF-- | Decimal value                                                                                                                                     | "Weight": 3.14                                  |
+| Field                     | Alt            | MFFSM | Value Type                                                                                                                                       | Example                                          |
+| ------------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| AccelerationRate          |                | MFF-- | Decimal value                                                                                                                                    | "AccelerationRate": 3.14                         |
+| ActorEffect               |                | MFFSM | Form Keys or Editor IDs                                                                                                                          |                                                  |
+| AimAngleTolerance         |                | MFF-- | Decimal value                                                                                                                                    | "AimAngleTolerance": 3.14                        |
+| AngularAccelerationRate   |                | MFF-- | Decimal value                                                                                                                                    | "AngularAccelerationRate": 3.14                  |
+| AngularTolerance          |                | MFF-- | Decimal value                                                                                                                                    | "AngularTolerance": 3.14                         |
+| ArmorRace                 | RNAM           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| AttackRace                | ATKR           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| BaseCarryWeight           |                | MFF-- | Decimal value                                                                                                                                    | "BaseCarryWeight": 3.14                          |
+| BaseMass                  |                | MFF-- | Decimal value                                                                                                                                    | "BaseMass": 3.14                                 |
+| BaseMovementDefaultFly    | FLMV           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| BaseMovementDefaultRun    | RNMV           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| BaseMovementDefaultSneak  | SNMV           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| BaseMovementDefaultSprint | SPMV           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| BaseMovementDefaultSwim   | SWMV           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| BaseMovementDefaultWalk   | WKMV           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| BodyBipedObject           |                | MF--- | Possible values (Head, Hair, Body, Hands, Forearms, Amulet, Ring, Feet, Calves, Shield, Tail, LongHair, Circlet, Ears, DecapitateHead, Decapitate, FX01, None) | "BodyBipedObject": "Head"                        |
+| BodyPartData              | GNAM           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| CloseLootSound            | LNAM           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| DecapitationFX            | NAM7           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| DecelerationRate          |                | MFF-- | Decimal value                                                                                                                                    | "DecelerationRate": 3.14                         |
+| Description               | DESC           | MFF-- | String value                                                                                                                                     | "Description": "Hello"                           |
+| EditorID                  | EDID           | MFF-- | String value                                                                                                                                     | "EditorID": "Hello"                              |
+| EquipmentFlags            | VNAM           | MF--- | Flags (HandToHand, OneHandSword, OneHandDagger, OneHandAxe, OneHandMace, TwoHandSword, TwoHandAxe, Bow, Staff, Spell, Shield, Torch, Crossbow)   | "EquipmentFlags": [ "HandToHand", "-Crossbow" ]  |
+| EquipmentSlots            | QNAM           | MFFSM | Form Keys or Editor IDs                                                                                                                          |                                                  |
+| ExportingExtraNam2        |                | MFF-- | True / False                                                                                                                                     | "ExportingExtraNam2": true                       |
+| Eyes                      | ENAM           | MFFSM | Form Keys or Editor IDs                                                                                                                          |                                                  |
+| FacegenFaceClamp          | UNAM           | MFF-- | Decimal value                                                                                                                                    | "FacegenFaceClamp": 3.14                         |
+| FacegenMainClamp          | PNAM           | MFF-- | Decimal value                                                                                                                                    | "FacegenMainClamp": 3.14                         |
+| Flags                     | DataFlags;FNAM | MF--- | Flags (Playable, FaceGenHead, Child, TiltFrontBack, TiltLeftRight, NoShadow, Swims, Flies, Walks, Immobile, NotPunishable, NoCombatInWater, NoRotatingToHeadTrack, DontShowBloodSpray, DontShowBloodDecal, UsesHeadTrackAnims, SpellsAlignWithMagicNode, UseWorldRaycastsForFootIK, AllowRagdollCollision, RegenHpInCombat, CantOpenDoors, AllowPcDialog, NoKnockdowns, AllowPickpocket, AlwaysUseProxyController, DontShowWeaponBlood, OverlayHeadPartList, OverrideHeadPartList, CanPickupItems, AllowMultipleMembraneShaders, CanDualWield, AvoidsRoads, UseAdvancedAvoidance, NonHostile, AllowMountedCombat) | "Flags": [ "Playable", "-AllowMountedCombat" ]   |
+| FlightRadius              |                | MFF-- | Decimal value                                                                                                                                    | "FlightRadius": 3.14                             |
+| FormVersion               |                | MFF-- | Numeric value                                                                                                                                    | "FormVersion": 7                                 |
+| HairBipedObject           |                | MF--- | Possible values (Head, Hair, Body, Hands, Forearms, Amulet, Ring, Feet, Calves, Shield, Tail, LongHair, Circlet, Ears, DecapitateHead, Decapitate, FX01, None) | "HairBipedObject": "Head"                        |
+| Hairs                     | HNAM           | MFFSM | Form Keys or Editor IDs                                                                                                                          |                                                  |
+| HeadBipedObject           |                | MF--- | Possible values (Head, Hair, Body, Hands, Forearms, Amulet, Ring, Feet, Calves, Shield, Tail, LongHair, Circlet, Ears, DecapitateHead, Decapitate, FX01, None) | "HeadBipedObject": "Head"                        |
+| ImpactDataSet             | NAM5           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| InjuredHealthPercent      |                | MFF-- | Decimal value                                                                                                                                    | "InjuredHealthPercent": 3.14                     |
+| Keywords                  | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                                                          |                                                  |
+| MajorFlags                | RecordFlags    | MF--- | Flags (Critter)                                                                                                                                  | "MajorFlags": "Critter"                          |
+| MaterialType              | NAM4           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| MorphRace                 | NAM8           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| Name                      | FULL           | MFF-- | String value                                                                                                                                     | "Name": "Hello"                                  |
+| NumberOfTintsInList       |                | MFF-- | Numeric value                                                                                                                                    | "NumberOfTintsInList": 7                         |
+| OpenLootSound             | ONAM           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| ShieldBipedObject         |                | MF--- | Possible values (Head, Hair, Body, Hands, Forearms, Amulet, Ring, Feet, Calves, Shield, Tail, LongHair, Circlet, Ears, DecapitateHead, Decapitate, FX01, None) | "ShieldBipedObject": "Head"                      |
+| Size                      |                | MF--- | Possible values (Small, Medium, Large, ExtraLarge)                                                                                               | "Size": "Small"                                  |
+| Skin                      | WNAM           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| SkyrimMajorRecordFlags    |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)        | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| UnarmedDamage             |                | MFF-- | Decimal value                                                                                                                                    | "UnarmedDamage": 3.14                            |
+| UnarmedEquipSlot          | UNES           | MFF-- | Form Key or Editor ID                                                                                                                            |                                                  |
+| UnarmedReach              |                | MFF-- | Decimal value                                                                                                                                    | "UnarmedReach": 3.14                             |
+| Weight                    |                | MFF-- | Decimal value                                                                                                                                    | "Weight": 3.14                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## REGN - Region
 
-| Field      | Alt         | MFFSM | Value Type                                                                                                                                                                             | Example                      |
-| ---------- | ----------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| MajorFlags | RecordFlags | MF--- | Flags (BorderRegion)                                                                                                                                                                   | "MajorFlags": "BorderRegion" |
-| MapColor   |             | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "MapColor": [40,50,60]       |
-| Worldspace |             | MFF-- | Form Key or Editor ID                                                                                                                                                                  |                              |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                             | Example                                          |
+| ---------------------- | ----------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                                           | "EditorID": "Hello"                              |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                                          | "FormVersion": 7                                 |
+| MajorFlags             | RecordFlags | MF--- | Flags (BorderRegion)                                                                                                                                   | "MajorFlags": "BorderRegion"                     |
+| MapColor               | RCLR        | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "MapColor": [40,50,60]                           |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)              | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Worldspace             | WNAM        | MFF-- | Form Key or Editor ID                                                                                                                                  |                                                  |
 
 [⬅ Back to Types](Types.md)
 
 ## RELA - Relationship
 
-| Field           | Alt            | MFFSM | Value Type                                                                                     | Example                |
-| --------------- | -------------- | ----- | ---------------------------------------------------------------------------------------------- | ---------------------- |
-| AssociationType |                | MFF-- | Form Key or Editor ID                                                                          |                        |
-| Child           |                | MFF-- | Form Key or Editor ID                                                                          |                        |
-| Flags           | DataFlags;FNAM | MF--- | Flags (Secret)                                                                                 | "Flags": "Secret"      |
-| MajorFlags      | RecordFlags    | MF--- | Flags (Secret)                                                                                 | "MajorFlags": "Secret" |
-| Parent          |                | MFF-- | Form Key or Editor ID                                                                          |                        |
-| Rank            |                | MF--- | Possible values (Lover, Ally, Confidant, Friend, Acquaintance, Rival, Foe, Enemy, Archnemesis) | "Rank": "Lover"        |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AssociationType        |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Child                  |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (Secret)                                                                                                                            | "Flags": "Secret"                                |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| MajorFlags             | RecordFlags    | MF--- | Flags (Secret)                                                                                                                            | "MajorFlags": "Secret"                           |
+| Parent                 |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Rank                   |                | MF--- | Possible values (Lover, Ally, Confidant, Friend, Acquaintance, Rival, Foe, Enemy, Archnemesis)                                            | "Rank": "Lover"                                  |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## REVB - ReverbParameters
 
-| Field             | Alt | MFFSM | Value Type                                               | Example                     |
-| ----------------- | --- | ----- | -------------------------------------------------------- | --------------------------- |
-| DecayHfRatio      |     | MFF-- | Decimal value                                            | "DecayHfRatio": 3.14        |
-| DecayMilliseconds |     | MFF-- | Numeric value                                            | "DecayMilliseconds": 7      |
-| DensityPercent    |     | -FF-- | Decimal value between 0.00 - 1.00, or string ending in % | "DensityPercent": "30.5%"   |
-| DiffusionPercent  |     | -FF-- | Decimal value between 0.00 - 1.00, or string ending in % | "DiffusionPercent": "30.5%" |
-| HfReferenceHertz  |     | MFF-- | Numeric value                                            | "HfReferenceHertz": 7       |
-| ReflectDelayMS    |     | MFF-- | Numeric value                                            | "ReflectDelayMS": 7         |
-| Reflections       |     | MFF-- | Numeric value                                            | "Reflections": 7            |
-| ReverbAmp         |     | MFF-- | Numeric value                                            | "ReverbAmp": 7              |
-| ReverbDelayMS     |     | MFF-- | Numeric value                                            | "ReverbDelayMS": 7          |
-| RoomFilter        |     | MFF-- | Numeric value                                            | "RoomFilter": 7             |
-| RoomHfFilter      |     | MFF-- | Numeric value                                            | "RoomHfFilter": 7           |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| DecayHfRatio           |      | MFF-- | Decimal value                                                                                                                             | "DecayHfRatio": 3.14                             |
+| DecayMilliseconds      |      | MFF-- | Numeric value                                                                                                                             | "DecayMilliseconds": 7                           |
+| DensityPercent         |      | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                                  | "DensityPercent": "30.5%"                        |
+| DiffusionPercent       |      | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                                  | "DiffusionPercent": "30.5%"                      |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| HfReferenceHertz       |      | MFF-- | Numeric value                                                                                                                             | "HfReferenceHertz": 7                            |
+| ReflectDelayMS         |      | MFF-- | Numeric value                                                                                                                             | "ReflectDelayMS": 7                              |
+| Reflections            |      | MFF-- | Numeric value                                                                                                                             | "Reflections": 7                                 |
+| ReverbAmp              |      | MFF-- | Numeric value                                                                                                                             | "ReverbAmp": 7                                   |
+| ReverbDelayMS          |      | MFF-- | Numeric value                                                                                                                             | "ReverbDelayMS": 7                               |
+| RoomFilter             |      | MFF-- | Numeric value                                                                                                                             | "RoomFilter": 7                                  |
+| RoomHfFilter           |      | MFF-- | Numeric value                                                                                                                             | "RoomHfFilter": 7                                |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## SCEN - Scene
 
-| Field           | Alt            | MFFSM | Value Type                                                                          | Example                                            |
-| --------------- | -------------- | ----- | ----------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Flags           | DataFlags;FNAM | MF--- | Flags (BeginOnQuestStart, StopQuestOnEnd, RepeatConditionsWhileTrue, Interruptable) | "Flags": [ "BeginOnQuestStart", "-Interruptable" ] |
-| LastActionIndex |                | MFF-- | Numeric value                                                                       | "LastActionIndex": 7                               |
-| Quest           |                | MFF-- | Form Key or Editor ID                                                               |                                                    |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                            |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (BeginOnQuestStart, StopQuestOnEnd, RepeatConditionsWhileTrue, Interruptable)                                                       | "Flags": [ "BeginOnQuestStart", "-Interruptable" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                   |
+| LastActionIndex        | INAM           | MFF-- | Numeric value                                                                                                                             | "LastActionIndex": 7                               |
+| Quest                  | PNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                    |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]   |
+| VNAM                   |                | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## SCRL - Scroll
 
-| Field             | Alt            | MFFSM | Value Type                                                                                                         | Example                                                                                |
-| ----------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| BaseCost          |                | MFF-- | Numeric value                                                                                                      | "BaseCost": 7                                                                          |
-| CastDuration      |                | MFF-- | Decimal value                                                                                                      | "CastDuration": 3.14                                                                   |
-| CastType          |                | MF--- | Possible values (ConstantEffect, FireAndForget, Concentration)                                                     | "CastType": "ConstantEffect"                                                           |
-| ChargeTime        |                | MFF-- | Decimal value                                                                                                      | "ChargeTime": 3.14                                                                     |
-| Description       | DESC           | MFF-- | String value                                                                                                       | "Description": "Hello"                                                                 |
-| Effects           |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data                                                  | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
-| EquipmentType     | ETYP           | MFF-- | Form Key or Editor ID                                                                                              |                                                                                        |
-| Flags             | DataFlags;FNAM | MF--- | Flags (ManualCostCalc, PCStartSpell, AreaEffectIgnoresLOS, IgnoreResistance, NoAbsorbOrReflect, NoDualCastModification) | "Flags": [ "ManualCostCalc", "-NoDualCastModification" ]                               |
-| HalfCostPerk      |                | MFF-- | Form Key or Editor ID                                                                                              |                                                                                        |
-| Keywords          | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                            |                                                                                        |
-| MenuDisplayObject | MDOB           | MFF-- | Form Key or Editor ID                                                                                              |                                                                                        |
-| Name              | FULL           | MFF-- | String value                                                                                                       | "Name": "Hello"                                                                        |
-| ObjectBounds      | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                           | "ObjectBounds": [6,6,6,9,9,9]                                                          |
-| PickUpSound       | YNAM           | MFF-- | Form Key or Editor ID                                                                                              |                                                                                        |
-| PutDownSound      | ZNAM           | MFF-- | Form Key or Editor ID                                                                                              |                                                                                        |
-| Range             |                | MFF-- | Decimal value                                                                                                      | "Range": 3.14                                                                          |
-| TargetType        |                | MF--- | Possible values (Self, Touch, Aimed, TargetActor, TargetLocation)                                                  | "TargetType": "Self"                                                                   |
-| Type              |                | MF--- | Possible values (Spell, Disease, Power, LesserPower, Ability, Poison, Addiction, Voice)                            | "Type": "Spell"                                                                        |
-| Value             |                | MFF-- | Numeric value                                                                                                      | "Value": 7                                                                             |
-| Weight            |                | MFF-- | Decimal value                                                                                                      | "Weight": 3.14                                                                         |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                    | Example                                                                                |
+| ---------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| BaseCost               |                | MFF-- | Numeric value                                                                                                 | "BaseCost": 7                                                                          |
+| CastDuration           |                | MFF-- | Decimal value                                                                                                 | "CastDuration": 3.14                                                                   |
+| CastType               |                | MF--- | Possible values (ConstantEffect, FireAndForget, Concentration)                                                | "CastType": "ConstantEffect"                                                           |
+| ChargeTime             |                | MFF-- | Decimal value                                                                                                 | "ChargeTime": 3.14                                                                     |
+| Description            | DESC           | MFF-- | String value                                                                                                  | "Description": "Hello"                                                                 |
+| EditorID               | EDID           | MFF-- | String value                                                                                                  | "EditorID": "Hello"                                                                    |
+| Effects                |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data                                             | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
+| EquipmentType          | ETYP           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (ManualCostCalc, PCStartSpell, AreaEffectIgnoresLOS, IgnoreResistance, NoAbsorbOrReflect, NoDualCastModification) | "Flags": [ "ManualCostCalc", "-NoDualCastModification" ]                               |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                 | "FormVersion": 7                                                                       |
+| HalfCostPerk           |                | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Keywords               | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                       |                                                                                        |
+| MenuDisplayObject      | MDOB           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Name                   | FULL           | MFF-- | String value                                                                                                  | "Name": "Hello"                                                                        |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                      | "ObjectBounds": [6,6,6,9,9,9]                                                          |
+| PickUpSound            | YNAM           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| PutDownSound           | ZNAM           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Range                  |                | MFF-- | Decimal value                                                                                                 | "Range": 3.14                                                                          |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                                       |
+| TargetType             |                | MF--- | Possible values (Self, Touch, Aimed, TargetActor, TargetLocation)                                             | "TargetType": "Self"                                                                   |
+| Type                   |                | MF--- | Possible values (Spell, Disease, Power, LesserPower, Ability, Poison, Addiction, Voice)                       | "Type": "Spell"                                                                        |
+| Value                  |                | MFF-- | Numeric value                                                                                                 | "Value": 7                                                                             |
+| Weight                 |                | MFF-- | Decimal value                                                                                                 | "Weight": 3.14                                                                         |
 
 [⬅ Back to Types](Types.md)
 
 ## SPGD - ShaderParticleGeometry
 
-| Field                | Alt | MFFSM | Value Type                   | Example                      |
-| -------------------- | --- | ----- | ---------------------------- | ---------------------------- |
-| BoxSize              |     | MFF-- | Numeric value                | "BoxSize": 7                 |
-| CenterOffsetMax      |     | MFF-- | Decimal value                | "CenterOffsetMax": 3.14      |
-| CenterOffsetMin      |     | MFF-- | Decimal value                | "CenterOffsetMin": 3.14      |
-| GravityVelocity      |     | MFF-- | Decimal value                | "GravityVelocity": 3.14      |
-| InitialRotationRange |     | MFF-- | Decimal value                | "InitialRotationRange": 3.14 |
-| NumSubtexturesX      |     | MFF-- | Numeric value                | "NumSubtexturesX": 7         |
-| NumSubtexturesY      |     | MFF-- | Numeric value                | "NumSubtexturesY": 7         |
-| ParticleDensity      |     | MFF-- | Decimal value                | "ParticleDensity": 3.14      |
-| ParticleSizeX        |     | MFF-- | Decimal value                | "ParticleSizeX": 3.14        |
-| ParticleSizeY        |     | MFF-- | Decimal value                | "ParticleSizeY": 3.14        |
-| RotationVelocity     |     | MFF-- | Decimal value                | "RotationVelocity": 3.14     |
-| Type                 |     | MF--- | Possible values (Rain, Snow) | "Type": "Rain"               |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| BoxSize                |      | MFF-- | Numeric value                                                                                                                             | "BoxSize": 7                                     |
+| CenterOffsetMax        |      | MFF-- | Decimal value                                                                                                                             | "CenterOffsetMax": 3.14                          |
+| CenterOffsetMin        |      | MFF-- | Decimal value                                                                                                                             | "CenterOffsetMin": 3.14                          |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| GravityVelocity        |      | MFF-- | Decimal value                                                                                                                             | "GravityVelocity": 3.14                          |
+| InitialRotationRange   |      | MFF-- | Decimal value                                                                                                                             | "InitialRotationRange": 3.14                     |
+| NumSubtexturesX        |      | MFF-- | Numeric value                                                                                                                             | "NumSubtexturesX": 7                             |
+| NumSubtexturesY        |      | MFF-- | Numeric value                                                                                                                             | "NumSubtexturesY": 7                             |
+| ParticleDensity        |      | MFF-- | Decimal value                                                                                                                             | "ParticleDensity": 3.14                          |
+| ParticleSizeX          |      | MFF-- | Decimal value                                                                                                                             | "ParticleSizeX": 3.14                            |
+| ParticleSizeY          |      | MFF-- | Decimal value                                                                                                                             | "ParticleSizeY": 3.14                            |
+| RotationVelocity       |      | MFF-- | Decimal value                                                                                                                             | "RotationVelocity": 3.14                         |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Type                   |      | MF--- | Possible values (Rain, Snow)                                                                                                              | "Type": "Rain"                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## SHOU - Shout
 
-| Field             | Alt         | MFFSM | Value Type                  | Example                             |
-| ----------------- | ----------- | ----- | --------------------------- | ----------------------------------- |
-| Description       | DESC        | MFF-- | String value                | "Description": "Hello"              |
-| MajorFlags        | RecordFlags | MF--- | Flags (TreatSpellsAsPowers) | "MajorFlags": "TreatSpellsAsPowers" |
-| MenuDisplayObject |             | MFF-- | Form Key or Editor ID       |                                     |
-| Name              | FULL        | MFF-- | String value                | "Name": "Hello"                     |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Description            | DESC        | MFF-- | String value                                                                                                                              | "Description": "Hello"                           |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| MajorFlags             | RecordFlags | MF--- | Flags (TreatSpellsAsPowers)                                                                                                               | "MajorFlags": "TreatSpellsAsPowers"              |
+| MenuDisplayObject      | MDOB        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Name                   | FULL        | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## SLGM - SoulGem
 
-| Field           | Alt         | MFFSM | Value Type                                                    | Example                        |
-| --------------- | ----------- | ----- | ------------------------------------------------------------- | ------------------------------ |
-| ContainedSoul   |             | MF--- | Possible values (None, Petty, Lesser, Common, Greater, Grand) | "ContainedSoul": "None"        |
-| Keywords        | KWDA        | MFFSM | Form Keys or Editor IDs                                       |                                |
-| LinkedTo        |             | MFF-- | Form Key or Editor ID                                         |                                |
-| MajorFlags      | RecordFlags | MF--- | Flags (CanHoldNpcSoul)                                        | "MajorFlags": "CanHoldNpcSoul" |
-| MaximumCapacity |             | MF--- | Possible values (None, Petty, Lesser, Common, Greater, Grand) | "MaximumCapacity": "None"      |
-| Name            | FULL        | MFF-- | String value                                                  | "Name": "Hello"                |
-| ObjectBounds    | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]      | "ObjectBounds": [6,6,6,9,9,9]  |
-| PickUpSound     | YNAM        | MFF-- | Form Key or Editor ID                                         |                                |
-| PutDownSound    | ZNAM        | MFF-- | Form Key or Editor ID                                         |                                |
-| Value           |             | MFF-- | Numeric value                                                 | "Value": 7                     |
-| Weight          |             | MFF-- | Decimal value                                                 | "Weight": 3.14                 |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| ContainedSoul          | SOUL        | MF--- | Possible values (None, Petty, Lesser, Common, Greater, Grand)                                                                             | "ContainedSoul": "None"                          |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Keywords               | KWDA        | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| LinkedTo               | NAM0        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| MajorFlags             | RecordFlags | MF--- | Flags (CanHoldNpcSoul)                                                                                                                    | "MajorFlags": "CanHoldNpcSoul"                   |
+| MaximumCapacity        | SLCP        | MF--- | Possible values (None, Petty, Lesser, Common, Greater, Grand)                                                                             | "MaximumCapacity": "None"                        |
+| Name                   | FULL        | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| ObjectBounds           | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| PickUpSound            | YNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PutDownSound           | ZNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Value                  |             | MFF-- | Numeric value                                                                                                                             | "Value": 7                                       |
+| Weight                 |             | MFF-- | Decimal value                                                                                                                             | "Weight": 3.14                                   |
 
 [⬅ Back to Types](Types.md)
 
 ## SNCT - SoundCategory
 
-| Field                  | Alt            | MFFSM | Value Type                                    | Example                                                 |
-| ---------------------- | -------------- | ----- | --------------------------------------------- | ------------------------------------------------------- |
-| DefaultMenuVolume      |                | MFF-- | Decimal value                                 | "DefaultMenuVolume": 3.14                               |
-| Flags                  | DataFlags;FNAM | MF--- | Flags (MuteWhenSubmerged, ShouldAppearOnMenu) | "Flags": [ "MuteWhenSubmerged", "-ShouldAppearOnMenu" ] |
-| Name                   | FULL           | MFF-- | String value                                  | "Name": "Hello"                                         |
-| Parent                 |                | MFF-- | Form Key or Editor ID                         |                                                         |
-| StaticVolumeMultiplier |                | MFF-- | Decimal value                                 | "StaticVolumeMultiplier": 3.14                          |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                                 |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| DefaultMenuVolume      | UNAM           | MFF-- | Decimal value                                                                                                                             | "DefaultMenuVolume": 3.14                               |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                     |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (MuteWhenSubmerged, ShouldAppearOnMenu)                                                                                             | "Flags": [ "MuteWhenSubmerged", "-ShouldAppearOnMenu" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                        |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                         |
+| Parent                 | PNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                         |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]        |
+| StaticVolumeMultiplier | VNAM           | MFF-- | Decimal value                                                                                                                             | "StaticVolumeMultiplier": 3.14                          |
 
 [⬅ Back to Types](Types.md)
 
 ## SNDR - SoundDescriptor
 
-| Field                    | Alt | MFFSM | Value Type                                               | Example                             |
-| ------------------------ | --- | ----- | -------------------------------------------------------- | ----------------------------------- |
-| AlternateSoundFor        |     | MFF-- | Form Key or Editor ID                                    |                                     |
-| Category                 |     | MFF-- | Form Key or Editor ID                                    |                                     |
-| OutputModel              |     | MFF-- | Form Key or Editor ID                                    |                                     |
-| PercentFrequencyShift    |     | -FF-- | Decimal value between 0.00 - 1.00, or string ending in % | "PercentFrequencyShift": "30.5%"    |
-| PercentFrequencyVariance |     | -FF-- | Decimal value between 0.00 - 1.00, or string ending in % | "PercentFrequencyVariance": "30.5%" |
-| Priority                 |     | MFF-- | Numeric value                                            | "Priority": 7                       |
-| StaticAttenuation        |     | MFF-- | Decimal value                                            | "StaticAttenuation": 3.14           |
-| String                   |     | MFF-- | String value                                             | "String": "Hello"                   |
-| Type                     |     | MF--- | Possible values (Standard)                               | "Type": "Standard"                  |
-| Variance                 |     | MFF-- | Numeric value                                            | "Variance": 7                       |
+| Field                    | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ------------------------ | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AlternateSoundFor        | SNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Category                 | GNAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| EditorID                 | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion              |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| OutputModel              | ONAM | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PercentFrequencyShift    |      | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                                  | "PercentFrequencyShift": "30.5%"                 |
+| PercentFrequencyVariance |      | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                                  | "PercentFrequencyVariance": "30.5%"              |
+| Priority                 |      | MFF-- | Numeric value                                                                                                                             | "Priority": 7                                    |
+| SkyrimMajorRecordFlags   |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| StaticAttenuation        |      | MFF-- | Decimal value                                                                                                                             | "StaticAttenuation": 3.14                        |
+| String                   | FNAM | MFF-- | String value                                                                                                                              | "String": "Hello"                                |
+| Type                     | CNAM | MF--- | Possible values (Standard)                                                                                                                | "Type": "Standard"                               |
+| Variance                 |      | MFF-- | Numeric value                                                                                                                             | "Variance": 7                                    |
 
 [⬅ Back to Types](Types.md)
 
 ## SOUN - SoundMarker
 
-| Field           | Alt  | MFFSM | Value Type                                               | Example                       |
-| --------------- | ---- | ----- | -------------------------------------------------------- | ----------------------------- |
-| ObjectBounds    | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9] |
-| SoundDescriptor |      | MFF-- | Form Key or Editor ID                                    |                               |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FNAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| ObjectBounds           | OBND | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| SNDD                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| SoundDescriptor        | SDSC | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
 
 [⬅ Back to Types](Types.md)
 
 ## SOPM - SoundOutputModel
 
-| Field | Alt | MFFSM | Value Type                                       | Example            |
-| ----- | --- | ----- | ------------------------------------------------ | ------------------ |
-| Type  |     | MF--- | Possible values (UsesHrtf, DefinedSpeakerOutput) | "Type": "UsesHrtf" |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| CNAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FNAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| SNAM                   |      | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| Type                   | MNAM | MF--- | Possible values (UsesHrtf, DefinedSpeakerOutput)                                                                                          | "Type": "UsesHrtf"                               |
 
 [⬅ Back to Types](Types.md)
 
 ## SPEL - Spell
 
-| Field             | Alt            | MFFSM | Value Type                                                                                                         | Example                                                                                |
-| ----------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| BaseCost          |                | MFF-- | Numeric value                                                                                                      | "BaseCost": 7                                                                          |
-| CastDuration      |                | MFF-- | Decimal value                                                                                                      | "CastDuration": 3.14                                                                   |
-| CastType          |                | MF--- | Possible values (ConstantEffect, FireAndForget, Concentration)                                                     | "CastType": "ConstantEffect"                                                           |
-| ChargeTime        |                | MFF-- | Decimal value                                                                                                      | "ChargeTime": 3.14                                                                     |
-| Description       | DESC           | MFF-- | String value                                                                                                       | "Description": "Hello"                                                                 |
-| Effects           |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data                                                  | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
-| EquipmentType     | ETYP           | MFF-- | Form Key or Editor ID                                                                                              |                                                                                        |
-| Flags             | DataFlags;FNAM | MF--- | Flags (ManualCostCalc, PCStartSpell, AreaEffectIgnoresLOS, IgnoreResistance, NoAbsorbOrReflect, NoDualCastModification) | "Flags": [ "ManualCostCalc", "-NoDualCastModification" ]                               |
-| HalfCostPerk      |                | MFF-- | Form Key or Editor ID                                                                                              |                                                                                        |
-| Keywords          | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                            |                                                                                        |
-| MenuDisplayObject |                | MFF-- | Form Key or Editor ID                                                                                              |                                                                                        |
-| Name              | FULL           | MFF-- | String value                                                                                                       | "Name": "Hello"                                                                        |
-| ObjectBounds      | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                           | "ObjectBounds": [6,6,6,9,9,9]                                                          |
-| Range             |                | MFF-- | Decimal value                                                                                                      | "Range": 3.14                                                                          |
-| TargetType        |                | MF--- | Possible values (Self, Touch, Aimed, TargetActor, TargetLocation)                                                  | "TargetType": "Self"                                                                   |
-| Type              |                | MF--- | Possible values (Spell, Disease, Power, LesserPower, Ability, Poison, Addiction, Voice)                            | "Type": "Spell"                                                                        |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                    | Example                                                                                |
+| ---------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| BaseCost               |                | MFF-- | Numeric value                                                                                                 | "BaseCost": 7                                                                          |
+| CastDuration           |                | MFF-- | Decimal value                                                                                                 | "CastDuration": 3.14                                                                   |
+| CastType               |                | MF--- | Possible values (ConstantEffect, FireAndForget, Concentration)                                                | "CastType": "ConstantEffect"                                                           |
+| ChargeTime             |                | MFF-- | Decimal value                                                                                                 | "ChargeTime": 3.14                                                                     |
+| Description            | DESC           | MFF-- | String value                                                                                                  | "Description": "Hello"                                                                 |
+| EditorID               | EDID           | MFF-- | String value                                                                                                  | "EditorID": "Hello"                                                                    |
+| Effects                |                | MFFSM | JSON objects containing effect Form Key/Editor ID and effect data                                             | "Effects": { "Effect": "021FED:Skyrim.esm", "Area": 3, "Duration": 3, "Magnitude": 3 } |
+| EquipmentType          | ETYP           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (ManualCostCalc, PCStartSpell, AreaEffectIgnoresLOS, IgnoreResistance, NoAbsorbOrReflect, NoDualCastModification) | "Flags": [ "ManualCostCalc", "-NoDualCastModification" ]                               |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                 | "FormVersion": 7                                                                       |
+| HalfCostPerk           |                | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Keywords               | KWDA           | MFFSM | Form Keys or Editor IDs                                                                                       |                                                                                        |
+| MenuDisplayObject      | MDOB           | MFF-- | Form Key or Editor ID                                                                                         |                                                                                        |
+| Name                   | FULL           | MFF-- | String value                                                                                                  | "Name": "Hello"                                                                        |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                      | "ObjectBounds": [6,6,6,9,9,9]                                                          |
+| Range                  |                | MFF-- | Decimal value                                                                                                 | "Range": 3.14                                                                          |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]                                       |
+| TargetType             |                | MF--- | Possible values (Self, Touch, Aimed, TargetActor, TargetLocation)                                             | "TargetType": "Self"                                                                   |
+| Type                   |                | MF--- | Possible values (Spell, Disease, Power, LesserPower, Ability, Poison, Addiction, Voice)                       | "Type": "Spell"                                                                        |
 
 [⬅ Back to Types](Types.md)
 
 ## STAT - Static
 
-| Field             | Alt            | MFFSM | Value Type                                                                                                                                     | Example                                                    |
-| ----------------- | -------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| DNAMDataTypeState |                | MF--- | Flags (Break0)                                                                                                                                 | "DNAMDataTypeState": "Break0"                              |
-| Flags             | DataFlags;FNAM | MF--- | Flags (ConsideredSnow)                                                                                                                         | "Flags": "ConsideredSnow"                                  |
-| MajorFlags        | RecordFlags    | MF--- | Flags (NeverFades, HasTreeLOD, AddOnLODObject, HiddenFromLocalMap, HasDistantLOD, UsesHdLodTexture, HasCurrents, IsMarker, Obstacle, NavMeshGenerationFilter, NavMeshGenerationBoundingBox, ShowInWorldMap, NavMeshGenerationGround) | "MajorFlags": [ "NeverFades", "-NavMeshGenerationGround" ] |
-| Material          |                | MFF-- | Form Key or Editor ID                                                                                                                          |                                                            |
-| MaxAngle          |                | MFF-- | Decimal value                                                                                                                                  | "MaxAngle": 3.14                                           |
-| ObjectBounds      | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                       | "ObjectBounds": [6,6,6,9,9,9]                              |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                                    |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| DNAMDataTypeState      |                | MF--- | Flags (Break0)                                                                                                                            | "DNAMDataTypeState": "Break0"                              |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                        |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (ConsideredSnow)                                                                                                                    | "Flags": "ConsideredSnow"                                  |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                           |
+| MajorFlags             | RecordFlags    | MF--- | Flags (NeverFades, HasTreeLOD, AddOnLODObject, HiddenFromLocalMap, HasDistantLOD, UsesHdLodTexture, HasCurrents, IsMarker, Obstacle, NavMeshGenerationFilter, NavMeshGenerationBoundingBox, ShowInWorldMap, NavMeshGenerationGround) | "MajorFlags": [ "NeverFades", "-NavMeshGenerationGround" ] |
+| Material               |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                            |
+| MaxAngle               |                | MFF-- | Decimal value                                                                                                                             | "MaxAngle": 3.14                                           |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                              |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]           |
 
 [⬅ Back to Types](Types.md)
 
 ## TACT - TalkingActivator
 
-| Field        | Alt         | MFFSM | Value Type                                                | Example                                                 |
-| ------------ | ----------- | ----- | --------------------------------------------------------- | ------------------------------------------------------- |
-| FNAM         |             | MFF-- | Numeric value                                             | "FNAM": 7                                               |
-| Keywords     | KWDA        | MFFSM | Form Keys or Editor IDs                                   |                                                         |
-| LoopingSound |             | MFF-- | Form Key or Editor ID                                     |                                                         |
-| MajorFlags   | RecordFlags | MF--- | Flags (HiddenFromLocalMap, RandomAnimStart, RadioStation) | "MajorFlags": [ "HiddenFromLocalMap", "-RadioStation" ] |
-| Name         | FULL        | MFF-- | String value                                              | "Name": "Hello"                                         |
-| ObjectBounds | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]  | "ObjectBounds": [6,6,6,9,9,9]                           |
-| PNAM         |             | MFF-- | Numeric value                                             | "PNAM": 7                                               |
-| VoiceType    |             | MFF-- | Form Key or Editor ID                                     |                                                         |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                | Example                                                 |
+| ---------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                     |
+| FNAM                   |             | MFF-- | Numeric value                                                                                                                             | "FNAM": 7                                               |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                        |
+| Keywords               | KWDA        | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                         |
+| LoopingSound           | SNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                         |
+| MajorFlags             | RecordFlags | MF--- | Flags (HiddenFromLocalMap, RandomAnimStart, RadioStation)                                                                                 | "MajorFlags": [ "HiddenFromLocalMap", "-RadioStation" ] |
+| Name                   | FULL        | MFF-- | String value                                                                                                                              | "Name": "Hello"                                         |
+| ObjectBounds           | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                           |
+| PNAM                   |             | MFF-- | Numeric value                                                                                                                             | "PNAM": 7                                               |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]        |
+| VoiceType              | VNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                         |
 
 [⬅ Back to Types](Types.md)
 
 ## TXST - TextureSet
 
-| Field        | Alt            | MFFSM | Value Type                                                     | Example                                                 |
-| ------------ | -------------- | ----- | -------------------------------------------------------------- | ------------------------------------------------------- |
-| Flags        | DataFlags;FNAM | MF--- | Flags (NoSpecularMap, FaceGenTextures, HasModelSpaceNormalMap) | "Flags": [ "NoSpecularMap", "-HasModelSpaceNormalMap" ] |
-| ObjectBounds | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]       | "ObjectBounds": [6,6,6,9,9,9]                           |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                                 |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                     |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (NoSpecularMap, FaceGenTextures, HasModelSpaceNormalMap)                                                                            | "Flags": [ "NoSpecularMap", "-HasModelSpaceNormalMap" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                        |
+| ObjectBounds           | OBND           | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                           |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]        |
 
 [⬅ Back to Types](Types.md)
 
 ## TREE - Tree
 
-| Field             | Alt         | MFFSM | Value Type                                               | Example                       |
-| ----------------- | ----------- | ----- | -------------------------------------------------------- | ----------------------------- |
-| BranchFlexibility |             | MFF-- | Decimal value                                            | "BranchFlexibility": 3.14     |
-| HarvestSound      |             | MFF-- | Form Key or Editor ID                                    |                               |
-| Ingredient        |             | MFF-- | Form Key or Editor ID                                    |                               |
-| LeafAmplitude     |             | MFF-- | Decimal value                                            | "LeafAmplitude": 3.14         |
-| LeafFrequency     |             | MFF-- | Decimal value                                            | "LeafFrequency": 3.14         |
-| MajorFlags        | RecordFlags | MF--- | Flags (HasDistantLOD)                                    | "MajorFlags": "HasDistantLOD" |
-| Name              | FULL        | MFF-- | String value                                             | "Name": "Hello"               |
-| ObjectBounds      | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9] |
-| TrunkFlexibility  |             | MFF-- | Decimal value                                            | "TrunkFlexibility": 3.14      |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| BranchFlexibility      |             | MFF-- | Decimal value                                                                                                                             | "BranchFlexibility": 3.14                        |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| HarvestSound           | SNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Ingredient             | PFIG        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| LeafAmplitude          |             | MFF-- | Decimal value                                                                                                                             | "LeafAmplitude": 3.14                            |
+| LeafFrequency          |             | MFF-- | Decimal value                                                                                                                             | "LeafFrequency": 3.14                            |
+| MajorFlags             | RecordFlags | MF--- | Flags (HasDistantLOD)                                                                                                                     | "MajorFlags": "HasDistantLOD"                    |
+| Name                   | FULL        | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| ObjectBounds           | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| TrunkFlexibility       |             | MFF-- | Decimal value                                                                                                                             | "TrunkFlexibility": 3.14                         |
 
 [⬅ Back to Types](Types.md)
 
 ## RFCT - VisualEffect
 
-| Field     | Alt            | MFFSM | Value Type                                                  | Example                                               |
-| --------- | -------------- | ----- | ----------------------------------------------------------- | ----------------------------------------------------- |
-| EffectArt |                | MFF-- | Form Key or Editor ID                                       |                                                       |
-| Flags     | DataFlags;FNAM | MF--- | Flags (RotateToFaceTarget, AttachToCamera, InheritRotation) | "Flags": [ "RotateToFaceTarget", "-InheritRotation" ] |
-| Shader    |                | MFF-- | Form Key or Editor ID                                       |                                                       |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                               |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                                   |
+| EffectArt              |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                       |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (RotateToFaceTarget, AttachToCamera, InheritRotation)                                                                               | "Flags": [ "RotateToFaceTarget", "-InheritRotation" ] |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                      |
+| Shader                 |                | MFF-- | Form Key or Editor ID                                                                                                                     |                                                       |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]      |
 
 [⬅ Back to Types](Types.md)
 
 ## VTYP - VoiceType
 
-| Field | Alt            | MFFSM | Value Type                         | Example                                      |
-| ----- | -------------- | ----- | ---------------------------------- | -------------------------------------------- |
-| Flags | DataFlags;FNAM | MF--- | Flags (AllowDefaultDialog, Female) | "Flags": [ "AllowDefaultDialog", "-Female" ] |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (AllowDefaultDialog, Female)                                                                                                        | "Flags": [ "AllowDefaultDialog", "-Female" ]     |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
 
 [⬅ Back to Types](Types.md)
 
 ## WATR - Water
 
-| Field                          | Alt            | MFFSM | Value Type                                                                                                                                      | Example                                      |
-| ------------------------------ | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| DamagePerSecond                |                | MFF-- | Numeric value                                                                                                                                   | "DamagePerSecond": 7                         |
-| DeepColor                      |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "DeepColor": [40,50,60]                      |
-| DepthNormals                   |                | MFF-- | Decimal value                                                                                                                                   | "DepthNormals": 3.14                         |
-| DepthReflections               |                | MFF-- | Decimal value                                                                                                                                   | "DepthReflections": 3.14                     |
-| DepthRefraction                |                | MFF-- | Decimal value                                                                                                                                   | "DepthRefraction": 3.14                      |
-| DepthSpecularLighting          |                | MFF-- | Decimal value                                                                                                                                   | "DepthSpecularLighting": 3.14                |
-| DisplacementDampner            |                | MFF-- | Decimal value                                                                                                                                   | "DisplacementDampner": 3.14                  |
-| DisplacementFalloff            |                | MFF-- | Decimal value                                                                                                                                   | "DisplacementFalloff": 3.14                  |
-| DisplacementFoce               |                | MFF-- | Decimal value                                                                                                                                   | "DisplacementFoce": 3.14                     |
-| DisplacementStartingSize       |                | MFF-- | Decimal value                                                                                                                                   | "DisplacementStartingSize": 3.14             |
-| DisplacementVelocity           |                | MFF-- | Decimal value                                                                                                                                   | "DisplacementVelocity": 3.14                 |
-| DNAMDataTypeState              |                | MF--- | Flags (Break0)                                                                                                                                  | "DNAMDataTypeState": "Break0"                |
-| Flags                          | DataFlags;FNAM | MF--- | Flags (CausesDamage, EnableFlowmap, BlendNormals)                                                                                               | "Flags": [ "CausesDamage", "-BlendNormals" ] |
-| FogAboveWaterAmount            |                | MFF-- | Decimal value                                                                                                                                   | "FogAboveWaterAmount": 3.14                  |
-| FogAboveWaterDistanceFarPlane  |                | MFF-- | Decimal value                                                                                                                                   | "FogAboveWaterDistanceFarPlane": 3.14        |
-| FogAboveWaterDistanceNearPlane |                | MFF-- | Decimal value                                                                                                                                   | "FogAboveWaterDistanceNearPlane": 3.14       |
-| FogUnderWaterAmount            |                | MFF-- | Decimal value                                                                                                                                   | "FogUnderWaterAmount": 3.14                  |
-| FogUnderWaterDistanceFarPlane  |                | MFF-- | Decimal value                                                                                                                                   | "FogUnderWaterDistanceFarPlane": 3.14        |
-| FogUnderWaterDistanceNearPlane |                | MFF-- | Decimal value                                                                                                                                   | "FogUnderWaterDistanceNearPlane": 3.14       |
-| ImageSpace                     |                | MFF-- | Form Key or Editor ID                                                                                                                           |                                              |
-| Material                       |                | MFF-- | Form Key or Editor ID                                                                                                                           |                                              |
-| Name                           | FULL           | MFF-- | String value                                                                                                                                    | "Name": "Hello"                              |
-| NoiseFalloff                   |                | MFF-- | Decimal value                                                                                                                                   | "NoiseFalloff": 3.14                         |
-| NoiseFlowmapScale              |                | MFF-- | Decimal value                                                                                                                                   | "NoiseFlowmapScale": 3.14                    |
-| NoiseLayerOneAmplitudeScale    |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerOneAmplitudeScale": 3.14          |
-| NoiseLayerOneUvScale           |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerOneUvScale": 3.14                 |
-| NoiseLayerOneWindDirection     |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerOneWindDirection": 3.14           |
-| NoiseLayerOneWindSpeed         |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerOneWindSpeed": 3.14               |
-| NoiseLayerThreeAmplitudeScale  |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerThreeAmplitudeScale": 3.14        |
-| NoiseLayerThreeUvScale         |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerThreeUvScale": 3.14               |
-| NoiseLayerThreeWindDirection   |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerThreeWindDirection": 3.14         |
-| NoiseLayerThreeWindSpeed       |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerThreeWindSpeed": 3.14             |
-| NoiseLayerTwoAmplitudeScale    |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerTwoAmplitudeScale": 3.14          |
-| NoiseLayerTwoUvScale           |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerTwoUvScale": 3.14                 |
-| NoiseLayerTwoWindDirection     |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerTwoWindDirection": 3.14           |
-| NoiseLayerTwoWindSpeed         |                | MFF-- | Decimal value                                                                                                                                   | "NoiseLayerTwoWindSpeed": 3.14               |
-| Opacity                        |                | MFF-- | Numeric value                                                                                                                                   | "Opacity": 7                                 |
-| OpenSound                      |                | MFF-- | Form Key or Editor ID                                                                                                                           |                                              |
-| ReflectionColor                |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "ReflectionColor": [40,50,60]                |
-| ShallowColor                   |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "ShallowColor": [40,50,60]                   |
-| SpecularBrightness             |                | MFF-- | Decimal value                                                                                                                                   | "SpecularBrightness": 3.14                   |
-| SpecularPower                  |                | MFF-- | Decimal value                                                                                                                                   | "SpecularPower": 3.14                        |
-| SpecularRadius                 |                | MFF-- | Decimal value                                                                                                                                   | "SpecularRadius": 3.14                       |
-| SpecularSunPower               |                | MFF-- | Decimal value                                                                                                                                   | "SpecularSunPower": 3.14                     |
-| SpecularSunSparkleMagnitude    |                | MFF-- | Decimal value                                                                                                                                   | "SpecularSunSparkleMagnitude": 3.14          |
-| SpecularSunSparklePower        |                | MFF-- | Decimal value                                                                                                                                   | "SpecularSunSparklePower": 3.14              |
-| SpecularSunSpecularMagnitude   |                | MFF-- | Decimal value                                                                                                                                   | "SpecularSunSpecularMagnitude": 3.14         |
-| Spell                          |                | MFF-- | Form Key or Editor ID                                                                                                                           |                                              |
-| WaterFresnel                   |                | MFF-- | Decimal value                                                                                                                                   | "WaterFresnel": 3.14                         |
-| WaterReflectionMagnitude       |                | MFF-- | Decimal value                                                                                                                                   | "WaterReflectionMagnitude": 3.14             |
-| WaterReflectivity              |                | MFF-- | Decimal value                                                                                                                                   | "WaterReflectivity": 3.14                    |
-| WaterRefractionMagnitude       |                | MFF-- | Decimal value                                                                                                                                   | "WaterRefractionMagnitude": 3.14             |
+| Field                          | Alt            | MFFSM | Value Type                                                                                                                                  | Example                                          |
+| ------------------------------ | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| DamagePerSecond                |                | MFF-- | Numeric value                                                                                                                               | "DamagePerSecond": 7                             |
+| DeepColor                      |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "DeepColor": [40,50,60]                          |
+| DepthNormals                   |                | MFF-- | Decimal value                                                                                                                               | "DepthNormals": 3.14                             |
+| DepthReflections               |                | MFF-- | Decimal value                                                                                                                               | "DepthReflections": 3.14                         |
+| DepthRefraction                |                | MFF-- | Decimal value                                                                                                                               | "DepthRefraction": 3.14                          |
+| DepthSpecularLighting          |                | MFF-- | Decimal value                                                                                                                               | "DepthSpecularLighting": 3.14                    |
+| DisplacementDampner            |                | MFF-- | Decimal value                                                                                                                               | "DisplacementDampner": 3.14                      |
+| DisplacementFalloff            |                | MFF-- | Decimal value                                                                                                                               | "DisplacementFalloff": 3.14                      |
+| DisplacementFoce               |                | MFF-- | Decimal value                                                                                                                               | "DisplacementFoce": 3.14                         |
+| DisplacementStartingSize       |                | MFF-- | Decimal value                                                                                                                               | "DisplacementStartingSize": 3.14                 |
+| DisplacementVelocity           |                | MFF-- | Decimal value                                                                                                                               | "DisplacementVelocity": 3.14                     |
+| DNAMDataTypeState              |                | MF--- | Flags (Break0)                                                                                                                              | "DNAMDataTypeState": "Break0"                    |
+| EditorID                       | EDID           | MFF-- | String value                                                                                                                                | "EditorID": "Hello"                              |
+| Flags                          | DataFlags;FNAM | MF--- | Flags (CausesDamage, EnableFlowmap, BlendNormals)                                                                                           | "Flags": [ "CausesDamage", "-BlendNormals" ]     |
+| FogAboveWaterAmount            |                | MFF-- | Decimal value                                                                                                                               | "FogAboveWaterAmount": 3.14                      |
+| FogAboveWaterDistanceFarPlane  |                | MFF-- | Decimal value                                                                                                                               | "FogAboveWaterDistanceFarPlane": 3.14            |
+| FogAboveWaterDistanceNearPlane |                | MFF-- | Decimal value                                                                                                                               | "FogAboveWaterDistanceNearPlane": 3.14           |
+| FogUnderWaterAmount            |                | MFF-- | Decimal value                                                                                                                               | "FogUnderWaterAmount": 3.14                      |
+| FogUnderWaterDistanceFarPlane  |                | MFF-- | Decimal value                                                                                                                               | "FogUnderWaterDistanceFarPlane": 3.14            |
+| FogUnderWaterDistanceNearPlane |                | MFF-- | Decimal value                                                                                                                               | "FogUnderWaterDistanceNearPlane": 3.14           |
+| FormVersion                    |                | MFF-- | Numeric value                                                                                                                               | "FormVersion": 7                                 |
+| GNAM                           |                | -FF-- | Memory slice in form of array of bytes                                                                                                      | [0x1A,0x00,0x3F]                                 |
+| ImageSpace                     | INAM           | MFF-- | Form Key or Editor ID                                                                                                                       |                                                  |
+| Material                       | TNAM           | MFF-- | Form Key or Editor ID                                                                                                                       |                                                  |
+| MNAM                           |                | -FF-- | Memory slice in form of array of bytes                                                                                                      | [0x1A,0x00,0x3F]                                 |
+| Name                           | FULL           | MFF-- | String value                                                                                                                                | "Name": "Hello"                                  |
+| NoiseFalloff                   |                | MFF-- | Decimal value                                                                                                                               | "NoiseFalloff": 3.14                             |
+| NoiseFlowmapScale              |                | MFF-- | Decimal value                                                                                                                               | "NoiseFlowmapScale": 3.14                        |
+| NoiseLayerOneAmplitudeScale    |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerOneAmplitudeScale": 3.14              |
+| NoiseLayerOneUvScale           |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerOneUvScale": 3.14                     |
+| NoiseLayerOneWindDirection     |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerOneWindDirection": 3.14               |
+| NoiseLayerOneWindSpeed         |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerOneWindSpeed": 3.14                   |
+| NoiseLayerThreeAmplitudeScale  |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerThreeAmplitudeScale": 3.14            |
+| NoiseLayerThreeUvScale         |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerThreeUvScale": 3.14                   |
+| NoiseLayerThreeWindDirection   |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerThreeWindDirection": 3.14             |
+| NoiseLayerThreeWindSpeed       |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerThreeWindSpeed": 3.14                 |
+| NoiseLayerTwoAmplitudeScale    |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerTwoAmplitudeScale": 3.14              |
+| NoiseLayerTwoUvScale           |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerTwoUvScale": 3.14                     |
+| NoiseLayerTwoWindDirection     |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerTwoWindDirection": 3.14               |
+| NoiseLayerTwoWindSpeed         |                | MFF-- | Decimal value                                                                                                                               | "NoiseLayerTwoWindSpeed": 3.14                   |
+| Opacity                        | ANAM           | MFF-- | Numeric value                                                                                                                               | "Opacity": 7                                     |
+| OpenSound                      | SNAM           | MFF-- | Form Key or Editor ID                                                                                                                       |                                                  |
+| ReflectionColor                |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "ReflectionColor": [40,50,60]                    |
+| ShallowColor                   |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "ShallowColor": [40,50,60]                       |
+| SkyrimMajorRecordFlags         |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait)   | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| SpecularBrightness             |                | MFF-- | Decimal value                                                                                                                               | "SpecularBrightness": 3.14                       |
+| SpecularPower                  |                | MFF-- | Decimal value                                                                                                                               | "SpecularPower": 3.14                            |
+| SpecularRadius                 |                | MFF-- | Decimal value                                                                                                                               | "SpecularRadius": 3.14                           |
+| SpecularSunPower               |                | MFF-- | Decimal value                                                                                                                               | "SpecularSunPower": 3.14                         |
+| SpecularSunSparkleMagnitude    |                | MFF-- | Decimal value                                                                                                                               | "SpecularSunSparkleMagnitude": 3.14              |
+| SpecularSunSparklePower        |                | MFF-- | Decimal value                                                                                                                               | "SpecularSunSparklePower": 3.14                  |
+| SpecularSunSpecularMagnitude   |                | MFF-- | Decimal value                                                                                                                               | "SpecularSunSpecularMagnitude": 3.14             |
+| Spell                          | XNAM           | MFF-- | Form Key or Editor ID                                                                                                                       |                                                  |
+| WaterFresnel                   |                | MFF-- | Decimal value                                                                                                                               | "WaterFresnel": 3.14                             |
+| WaterReflectionMagnitude       |                | MFF-- | Decimal value                                                                                                                               | "WaterReflectionMagnitude": 3.14                 |
+| WaterReflectivity              |                | MFF-- | Decimal value                                                                                                                               | "WaterReflectivity": 3.14                        |
+| WaterRefractionMagnitude       |                | MFF-- | Decimal value                                                                                                                               | "WaterRefractionMagnitude": 3.14                 |
 
 [⬅ Back to Types](Types.md)
 
 ## WEAP - Weapon
 
-| Field                  | Alt         | MFFSM | Value Type                                               | Example                       |
-| ---------------------- | ----------- | ----- | -------------------------------------------------------- | ----------------------------- |
-| AlternateBlockMaterial | BAMT        | MFF-- | Form Key or Editor ID                                    |                               |
-| AttackFailSound        | TNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| AttackLoopSound        | NAM7        | MFF-- | Form Key or Editor ID                                    |                               |
-| AttackSound            | SNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| AttackSound2D          | XNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| BlockBashImpact        | BIDS        | MFF-- | Form Key or Editor ID                                    |                               |
-| Description            | DESC        | MFF-- | String value                                             | "Description": "Hello"        |
-| DetectionSoundLevel    |             | MF--- | Possible values (Loud, Normal, Silent, VeryLoud)         | "DetectionSoundLevel": "Loud" |
-| EnchantmentAmount      | EAMT        | MFF-- | Numeric value                                            | "EnchantmentAmount": 7        |
-| EquipmentType          | ETYP        | MFF-- | Form Key or Editor ID                                    |                               |
-| EquipSound             | NAM9        | MFF-- | Form Key or Editor ID                                    |                               |
-| FirstPersonModel       |             | MFF-- | Form Key or Editor ID                                    |                               |
-| IdleSound              | UNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| ImpactDataSet          | INAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| Keywords               | KWDA        | MFFSM | Form Keys or Editor IDs                                  |                               |
-| MajorFlags             | RecordFlags | MF--- | Flags (NonPlayable)                                      | "MajorFlags": "NonPlayable"   |
-| Name                   | FULL        | MFF-- | String value                                             | "Name": "Hello"               |
-| ObjectBounds           | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2] | "ObjectBounds": [6,6,6,9,9,9] |
-| ObjectEffect           | EITM        | MFF-- | Form Key or Editor ID                                    |                               |
-| PickUpSound            | YNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| PutDownSound           | ZNAM        | MFF-- | Form Key or Editor ID                                    |                               |
-| Template               |             | MFF-- | Form Key or Editor ID                                    |                               |
-| UnequipSound           | NAM8        | MFF-- | Form Key or Editor ID                                    |                               |
+| Field                  | Alt         | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| AlternateBlockMaterial | BAMT        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| AttackFailSound        | TNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| AttackLoopSound        | NAM7        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| AttackSound            | SNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| AttackSound2D          | XNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| BlockBashImpact        | BIDS        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Description            | DESC        | MFF-- | String value                                                                                                                              | "Description": "Hello"                           |
+| DetectionSoundLevel    | VNAM        | MF--- | Possible values (Loud, Normal, Silent, VeryLoud)                                                                                          | "DetectionSoundLevel": "Loud"                    |
+| EditorID               | EDID        | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| EnchantmentAmount      | EAMT        | MFF-- | Numeric value                                                                                                                             | "EnchantmentAmount": 7                           |
+| EquipmentType          | ETYP        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| EquipSound             | NAM9        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| FirstPersonModel       | WNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| FormVersion            |             | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| IdleSound              | UNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| ImpactDataSet          | INAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Keywords               | KWDA        | MFFSM | Form Keys or Editor IDs                                                                                                                   |                                                  |
+| MajorFlags             | RecordFlags | MF--- | Flags (NonPlayable)                                                                                                                       | "MajorFlags": "NonPlayable"                      |
+| Name                   | FULL        | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| ObjectBounds           | OBND        | -FF-- | Object bounds array of numbers. [x1, y1, z1, x2, y2, z2]                                                                                  | "ObjectBounds": [6,6,6,9,9,9]                    |
+| ObjectEffect           | EITM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PickUpSound            | YNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| PutDownSound           | ZNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| SkyrimMajorRecordFlags |             | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Template               | CNAM        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| UnequipSound           | NAM8        | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
 
 [⬅ Back to Types](Types.md)
 
@@ -1684,6 +2060,11 @@ This just details where the field can currently be used.
 
 | Field                       | Alt            | MFFSM | Value Type                                                                                                                             | Example                                                  |
 | --------------------------- | -------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| ANAM                        |                | -FF-- | Memory slice in form of array of bytes                                                                                                 | [0x1A,0x00,0x3F]                                         |
+| BNAM                        |                | -FF-- | Memory slice in form of array of bytes                                                                                                 | [0x1A,0x00,0x3F]                                         |
+| CNAM                        |                | -FF-- | Memory slice in form of array of bytes                                                                                                 | [0x1A,0x00,0x3F]                                         |
+| DNAM                        |                | -FF-- | Memory slice in form of array of bytes                                                                                                 | [0x1A,0x00,0x3F]                                         |
+| EditorID                    | EDID           | MFF-- | String value                                                                                                                           | "EditorID": "Hello"                                      |
 | Flags                       | DataFlags;FNAM | MF--- | Flags (Pleasant, Cloudy, Rainy, Snow, SkyStaticsAlwaysVisible, SkyStaticsFollowsSunPosition)                                           | "Flags": [ "Pleasant", "-SkyStaticsFollowsSunPosition" ] |
 | FogDistanceDayFar           |                | MFF-- | Decimal value                                                                                                                          | "FogDistanceDayFar": 3.14                                |
 | FogDistanceDayMax           |                | MFF-- | Decimal value                                                                                                                          | "FogDistanceDayMax": 3.14                                |
@@ -1693,20 +2074,26 @@ This just details where the field can currently be used.
 | FogDistanceNightMax         |                | MFF-- | Decimal value                                                                                                                          | "FogDistanceNightMax": 3.14                              |
 | FogDistanceNightNear        |                | MFF-- | Decimal value                                                                                                                          | "FogDistanceNightNear": 3.14                             |
 | FogDistanceNightPower       |                | MFF-- | Decimal value                                                                                                                          | "FogDistanceNightPower": 3.14                            |
+| FormVersion                 |                | MFF-- | Numeric value                                                                                                                          | "FormVersion": 7                                         |
 | LightningColor              |                | -FF-- | Color value as number, array of 3 or 4 numbers, or a string in the format of either Hex value ("#0A0A0A0A") or named color "Blue". Array and Hex are ARGB. Alpha portion of ARGB may be ignored for some fields and can be omitted. | "LightningColor": [40,50,60]                             |
+| LNAM                        |                | -FF-- | Memory slice in form of array of bytes                                                                                                 | [0x1A,0x00,0x3F]                                         |
 | NAM0DataTypeState           |                | MF--- | Flags (Break0, Break1)                                                                                                                 | "NAM0DataTypeState": [ "Break0", "-Break1" ]             |
-| Precipitation               |                | MFF-- | Form Key or Editor ID                                                                                                                  |                                                          |
+| NAM2                        |                | -FF-- | Memory slice in form of array of bytes                                                                                                 | [0x1A,0x00,0x3F]                                         |
+| NAM3                        |                | -FF-- | Memory slice in form of array of bytes                                                                                                 | [0x1A,0x00,0x3F]                                         |
+| ONAM                        |                | -FF-- | Memory slice in form of array of bytes                                                                                                 | [0x1A,0x00,0x3F]                                         |
+| Precipitation               | MNAM           | MFF-- | Form Key or Editor ID                                                                                                                  |                                                          |
 | PrecipitationBeginFadeIn    |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                               | "PrecipitationBeginFadeIn": "30.5%"                      |
 | PrecipitationEndFadeOut     |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                               | "PrecipitationEndFadeOut": "30.5%"                       |
+| SkyrimMajorRecordFlags      |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ]         |
 | SkyStatics                  |                | MFFSM | Form Keys or Editor IDs                                                                                                                |                                                          |
 | SunDamage                   |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                               | "SunDamage": "30.5%"                                     |
 | SunGlare                    |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                               | "SunGlare": "30.5%"                                      |
-| SunGlareLensFlare           |                | MFF-- | Form Key or Editor ID                                                                                                                  |                                                          |
+| SunGlareLensFlare           | GNAM           | MFF-- | Form Key or Editor ID                                                                                                                  |                                                          |
 | ThunderLightningBeginFadeIn |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                               | "ThunderLightningBeginFadeIn": "30.5%"                   |
 | ThunderLightningEndFadeOut  |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                               | "ThunderLightningEndFadeOut": "30.5%"                    |
 | ThunderLightningFrequency   |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                               | "ThunderLightningFrequency": "30.5%"                     |
 | TransDelta                  |                | MFF-- | Decimal value                                                                                                                          | "TransDelta": 3.14                                       |
-| VisualEffect                |                | MFF-- | Form Key or Editor ID                                                                                                                  |                                                          |
+| VisualEffect                | NNAM           | MFF-- | Form Key or Editor ID                                                                                                                  |                                                          |
 | VisualEffectBegin           |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                               | "VisualEffectBegin": "30.5%"                             |
 | VisualEffectEnd             |                | -FF-- | Decimal value between 0.00 - 1.00, or string ending in %                                                                               | "VisualEffectEnd": "30.5%"                               |
 | WindDirection               |                | MFF-- | Decimal value                                                                                                                          | "WindDirection": 3.14                                    |
@@ -1717,29 +2104,36 @@ This just details where the field can currently be used.
 
 ## WOOP - WordOfPower
 
-| Field       | Alt  | MFFSM | Value Type   | Example                |
-| ----------- | ---- | ----- | ------------ | ---------------------- |
-| Name        | FULL | MFF-- | String value | "Name": "Hello"        |
-| Translation |      | MFF-- | String value | "Translation": "Hello" |
+| Field                  | Alt  | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | ---- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| EditorID               | EDID | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| FormVersion            |      | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| Name                   | FULL | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| SkyrimMajorRecordFlags |      | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Translation            | TNAM | MFF-- | String value                                                                                                                              | "Translation": "Hello"                           |
 
 [⬅ Back to Types](Types.md)
 
 ## WRLD - Worldspace
 
-| Field                | Alt            | MFFSM | Value Type                                                                                     | Example                               |
-| -------------------- | -------------- | ----- | ---------------------------------------------------------------------------------------------- | ------------------------------------- |
-| Climate              | CNAM           | MFF-- | Form Key or Editor ID                                                                          |                                       |
-| DistantLodMultiplier | NAMA           | MFF-- | Decimal value                                                                                  | "DistantLodMultiplier": 3.14          |
-| EncounterZone        | XEZN           | MFF-- | Form Key or Editor ID                                                                          |                                       |
-| Flags                | DataFlags;FNAM | MF--- | Flags (SmallWorld, CannotFastTravel, NoLodWater, NoLandscape, NoSky, FixedDimensions, NoGrass) | "Flags": [ "SmallWorld", "-NoGrass" ] |
-| InteriorLighting     | LTMP           | MFF-- | Form Key or Editor ID                                                                          |                                       |
-| Location             | XLCN           | MFF-- | Form Key or Editor ID                                                                          |                                       |
-| LodWater             | NAM3           | MFF-- | Form Key or Editor ID                                                                          |                                       |
-| LodWaterHeight       | NAM4           | MFF-- | Decimal value                                                                                  | "LodWaterHeight": 3.14                |
-| MajorFlags           | RecordFlags    | MF--- | Flags (CanNotWait)                                                                             | "MajorFlags": "CanNotWait"            |
-| Music                | ZNAM           | MFF-- | Form Key or Editor ID                                                                          |                                       |
-| Name                 | FULL           | MFF-- | String value                                                                                   | "Name": "Hello"                       |
-| Water                | XCWT           | MFF-- | Form Key or Editor ID                                                                          |                                       |
-| WorldMapOffsetScale  |                | MFF-- | Decimal value                                                                                  | "WorldMapOffsetScale": 3.14           |
+| Field                  | Alt            | MFFSM | Value Type                                                                                                                                | Example                                          |
+| ---------------------- | -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Climate                | CNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| DistantLodMultiplier   | NAMA           | MFF-- | Decimal value                                                                                                                             | "DistantLodMultiplier": 3.14                     |
+| EditorID               | EDID           | MFF-- | String value                                                                                                                              | "EditorID": "Hello"                              |
+| EncounterZone          | XEZN           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Flags                  | DataFlags;FNAM | MF--- | Flags (SmallWorld, CannotFastTravel, NoLodWater, NoLandscape, NoSky, FixedDimensions, NoGrass)                                            | "Flags": [ "SmallWorld", "-NoGrass" ]            |
+| FormVersion            |                | MFF-- | Numeric value                                                                                                                             | "FormVersion": 7                                 |
+| InteriorLighting       | LTMP           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Location               | XLCN           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| LodWater               | NAM3           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| LodWaterHeight         | NAM4           | MFF-- | Decimal value                                                                                                                             | "LodWaterHeight": 3.14                           |
+| MajorFlags             | RecordFlags    | MF--- | Flags (CanNotWait)                                                                                                                        | "MajorFlags": "CanNotWait"                       |
+| Music                  | ZNAM           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| Name                   | FULL           | MFF-- | String value                                                                                                                              | "Name": "Hello"                                  |
+| OffsetData             | OFST           | -FF-- | Memory slice in form of array of bytes                                                                                                    | [0x1A,0x00,0x3F]                                 |
+| SkyrimMajorRecordFlags |                | MF--- | Flags (ESM, NotPlayable, Deleted, InitiallyDisabled, Ignored, VisibleWhenDistant, Dangerous_OffLimits_InteriorCell, Compressed, CantWait) | "SkyrimMajorRecordFlags": [ "ESM", "-CantWait" ] |
+| Water                  | XCWT           | MFF-- | Form Key or Editor ID                                                                                                                     |                                                  |
+| WorldMapOffsetScale    |                | MFF-- | Decimal value                                                                                                                             | "WorldMapOffsetScale": 3.14                      |
 
 [⬅ Back to Types](Types.md)

--- a/docs/Types.md
+++ b/docs/Types.md
@@ -5,6 +5,7 @@ You can use either the short type name or synonyms when listing types.
 | Type                                            | Synonyms               |
 | ----------------------------------------------- | ---------------------- |
 | [ASPC](Fields.md#aspc---acousticspace)          | AcousticSpace          |
+| [AACT](Fields.md#aact---actionrecord)           | ActionRecord           |
 | [ACTI](Fields.md#acti---activator)              | Activator              |
 | [AVIF](Fields.md#avif---actorvalueinformation)  | ActorValueInformation  |
 | [ADDN](Fields.md#addn---addonnode)              | AddonNode              |
@@ -14,6 +15,8 @@ You can use either the short type name or synonyms when listing types.
 | [ARMA](Fields.md#arma---armoraddon)             | ArmorAddon             |
 | [ARMO](Fields.md#armo---armor)                  | Armor                  |
 | [ARTO](Fields.md#arto---artobject)              | ArtObject              |
+| [ASTP](Fields.md#astp---associationtype)        | AssociationType        |
+| [BPTD](Fields.md#bptd---bodypartdata)           | BodyPartData           |
 | [BOOK](Fields.md#book)                          |                        |
 | [CPTH](Fields.md#cpth---camerapath)             | CameraPath             |
 | [CAMS](Fields.md#cams---camerashot)             | CameraShot             |
@@ -25,6 +28,8 @@ You can use either the short type name or synonyms when listing types.
 | [CSTY](Fields.md#csty---combatstyle)            | CombatStyle            |
 | [COBJ](Fields.md#cobj---constructibleobject)    | ConstructibleObject    |
 | [CONT](Fields.md#cont---container)              | Container              |
+| [DEBR](Fields.md#debr---debris)                 | Debris                 |
+| [DOBJ](Fields.md#dobj---defaultobjectmanager)   | DefaultObjectManager   |
 | [DLBR](Fields.md#dlbr---dialogbranch)           | DialogBranch           |
 | [DIAL](Fields.md#dial---dialogtopic)            | DialogTopic            |
 | [DLVW](Fields.md#dlvw---dialogview)             | DialogView             |
@@ -41,6 +46,7 @@ You can use either the short type name or synonyms when listing types.
 | [FSTS](Fields.md#fsts---footstepset)            | FootstepSet            |
 | [FLST](Fields.md#flst---formlist)               | FormList               |
 | [FURN](Fields.md#furn---furniture)              | Furniture              |
+| [GMST](Fields.md#gmst---gamesetting)            | GameSetting            |
 | [GLOB](Fields.md#glob---global)                 | Global                 |
 | [GRAS](Fields.md#gras---grass)                  | Grass                  |
 | [HAZD](Fields.md#hazd---hazard)                 | Hazard                 |
@@ -48,10 +54,13 @@ You can use either the short type name or synonyms when listing types.
 | [IDLE](Fields.md#idle---idleanimation)          | IdleAnimation          |
 | [IDLM](Fields.md#idlm---idlemarker)             | IdleMarker             |
 | [IMAD](Fields.md#imad---imagespaceadapter)      | ImageSpaceAdapter      |
+| [IMGS](Fields.md#imgs---imagespace)             | ImageSpace             |
+| [IPDS](Fields.md#ipds---impactdataset)          | ImpactDataSet          |
 | [IPCT](Fields.md#ipct---impact)                 | Impact                 |
 | [ALCH](Fields.md#alch---ingestible)             | Ingestible             |
 | [INGR](Fields.md#ingr---ingredient)             | Ingredient             |
 | [KEYM](Fields.md#keym---key)                    | Key                    |
+| [KYWD](Fields.md#kywd---keyword)                | Keyword                |
 | [LTEX](Fields.md#ltex---landscapetexture)       | LandscapeTexture       |
 | [LVLI](Fields.md#lvli---leveleditem)            | LeveledItem            |
 | [LVLN](Fields.md#lvln---levelednpc)             | LeveledNpc             |
@@ -60,6 +69,7 @@ You can use either the short type name or synonyms when listing types.
 | [LGTM](Fields.md#lgtm---lightingtemplate)       | LightingTemplate       |
 | [LSCR](Fields.md#lscr---loadscreen)             | LoadScreen             |
 | [LCTN](Fields.md#lctn---location)               | Location               |
+| [LCRT](Fields.md#lcrt---locationreferencetype)  | LocationReferenceType  |
 | [MGEF](Fields.md#mgef---magiceffect)            | MagicEffect            |
 | [MATO](Fields.md#mato---materialobject)         | MaterialObject         |
 | [MATT](Fields.md#matt---materialtype)           | MaterialType           |


### PR DESCRIPTION
Fixed code that enables fields on records that match implemented types.
  * Now confirms field is writable
  * Fixed missing fields
  * Fixed missing aliases

Added MemorySlice<Byte> support. Don’t expect this to be used directly and number of properties on records of this type unused. People using these fields should be careful.